### PR TITLE
Android: Add ability to enumerate dynamically registered broadcast receivers. 

### DIFF
--- a/objection/commands/android/hooking.py
+++ b/objection/commands/android/hooking.py
@@ -75,3 +75,31 @@ def dump_android_method_args(args: list) -> None:
                               target_class=target_class, target_method=target_method)
 
     runner.run_as_job(name='dump-arguments')
+
+def show_registered_broadcast_receivers(args: list= None) -> None:
+    """
+        Enumerate all the loaded classes that extend BroadcastReceiver
+        :param args:
+        :return:
+    """
+
+    hook = android_hook('hooking/list-broadcast-receivers')
+    runner = FridaRunner(hook=hook)
+    runner.run()
+
+    response = runner.get_last_message()
+
+    if not response.is_successful():
+        click.secho('Failed to list broadcast receivers with error: {0}'.format(response.error_reason), fg='red')
+        return None
+
+    if not response.data:
+        click.secho('No broadcast receivers were found', fg='yellow')
+        return None
+
+    for class_name in sorted(response.data):
+        click.secho(class_name)
+
+    click.secho('\nFound {0} classes'.format(len(response.data)), bold=True)
+
+    

--- a/objection/console/repository.py
+++ b/objection/console/repository.py
@@ -225,6 +225,10 @@ COMMANDS = {
                                 'meta': 'List the currently loaded classes',
                                 'exec': android_hooking.show_android_classes
                             },
+                            'receivers': {
+                                'meta': 'List the currently loaded BroadcastReceivers',
+                                'exec': android_hooking.show_registered_broadcast_receivers
+                            },
                         }
                     },
                     'watch': {

--- a/objection/hooks/android/hooking/list-broadcast-receivers.js
+++ b/objection/hooks/android/hooking/list-broadcast-receivers.js
@@ -27,7 +27,10 @@ receivers = receivers.concat(context.getPackageManager().getPackageInfo(context.
     return activity_info.name['value'];
 }))
 
-
+//Unique, will create duplicates if receiver in Manifest has been triggered by a broadcast
+receivers = receivers.filter(function(elem, pos) {
+    return receivers.indexOf(elem) == pos;
+}); 
 
 var response = {
     status: 'success',

--- a/objection/hooks/android/hooking/list-broadcast-receivers.js
+++ b/objection/hooks/android/hooking/list-broadcast-receivers.js
@@ -1,0 +1,32 @@
+// Lists the loaded classes that extend BroadcastReceiver available in the current Java
+// runtime.
+
+var BroadcastReceiver = Java.use("android.content.BroadcastReceiver")
+
+var classes = Java.enumerateLoadedClassesSync()
+
+
+var receivers = classes.filter(function(className){
+    //Exclude some classes to prevent Java.use blocking (Some memory management issue)
+    if (className.startsWith("android") || className.startsWith("java") || className.startsWith("com.android") || !className.includes(".")) return false;
+
+    //Some classes are not in search path resulting in Java.use throwing exception
+    try{
+        var clazz = Java.use(className);
+        var isReceiver = BroadcastReceiver.class.isAssignableFrom(clazz.class);
+        clazz.$dispose();
+        return isReceiver;
+    } catch (e){}
+    return false;
+})
+
+
+var response = {
+    status: 'success',
+    error_reason: NaN,
+    type: 'android-broadcast-receivers',
+    data: receivers
+}
+
+send(JSON.stringify(response));
+

--- a/objection/hooks/android/hooking/list-broadcast-receivers.js
+++ b/objection/hooks/android/hooking/list-broadcast-receivers.js
@@ -2,9 +2,12 @@
 // runtime.
 
 var BroadcastReceiver = Java.use("android.content.BroadcastReceiver")
+var ActivityThread = Java.use('android.app.ActivityThread');
+
+var currentApplication = ActivityThread.currentApplication();
+var context = currentApplication.getApplicationContext();
 
 var classes = Java.enumerateLoadedClassesSync()
-
 
 var receivers = classes.filter(function(className){
     //Exclude some classes to prevent Java.use blocking (Some memory management issue)
@@ -19,6 +22,11 @@ var receivers = classes.filter(function(className){
     } catch (e){}
     return false;
 })
+
+receivers = receivers.concat(context.getPackageManager().getPackageInfo(context.getPackageName(),0x00000002).receivers['value'].map(function(activity_info){
+    return activity_info.name['value'];
+}))
+
 
 
 var response = {


### PR DESCRIPTION
# Description # 

Inspect application's heap to find all the Broadcast Receivers that have been registered at Runtime. Does not list receivers defined in AndroidManifest.xml

# Test Application # 
```
package com.bw.receiverexample;

import android.content.BroadcastReceiver;
import android.content.Context;
import android.content.Intent;
import android.content.IntentFilter;
import android.support.v7.app.AppCompatActivity;
import android.os.Bundle;
import android.util.Log;

public class MainActivity extends AppCompatActivity {

    @Override
    protected void onCreate(Bundle savedInstanceState) {
        super.onCreate(savedInstanceState);
        setContentView(R.layout.activity_main);

        BroadcastReceiver receiver = new BroadcastReceiver() {
            @Override
            public void onReceive(Context context, Intent intent) {
                Log.d("ReceiverExample","Received intent with action:" + intent.getAction());
            }
        };

        this.registerReceiver(receiver, new IntentFilter("pew.pew.pew"));
    }
}
```

# Usage #

```
     _     _         _   _
 ___| |_  |_|___ ___| |_|_|___ ___
| . | . | | | -_|  _|  _| | . |   |
|___|___|_| |___|___|_| |_|___|_|_|
        |___|(object)inject(ion) v0.1.1

     Runtime Mobile Exploration
        by: @leonjza from @sensepost

[tab] for command suggestions
Nexus 5X on (google: 7.1.2) [usb] # android hooking list receivers
com.bw.receiverexample.MainActivity$1

Found 1 classes
```