### PR TITLE
Optimisation: list broadcast receivers by inspecting LoadedApk

### DIFF
--- a/objection/commands/android/hooking.py
+++ b/objection/commands/android/hooking.py
@@ -90,7 +90,7 @@ def dump_android_method_args(args: list) -> None:
 
 def show_registered_broadcast_receivers(args: list = None) -> None:
     """
-        Enumerate all the loaded classes that extend BroadcastReceiver
+        Enumerate all registered BroadcastReceivers
         :param args:
         :return:
     """

--- a/objection/console/commands.py
+++ b/objection/console/commands.py
@@ -228,7 +228,7 @@ COMMANDS = {
                                 'exec': android_hooking.show_android_classes
                             },
                             'receivers': {
-                                'meta': 'List the currently loaded BroadcastReceivers',
+                                'meta': 'List the registered BroadcastReceivers',
                                 'exec': android_hooking.show_registered_broadcast_receivers
                             },
                         }

--- a/objection/console/helpfiles/android.hooking.list.receivers.txt
+++ b/objection/console/helpfiles/android.hooking.list.receivers.txt
@@ -2,9 +2,8 @@ Command: android hooking list receivers
 
 Usage: android hooking list receivers
 
-Inspects the application's heap to find all of the Broadcast Receivers 
-that have been registered at Runtime as well as those specified by the
-AndroidManifest.xml.
+List all the registered Broadcast Receivers that have been registered 
+at Runtime as well as those specified by the AndroidManifest.xml.
 
 Examples:
    android hooking list receivers

--- a/objection/hooks/android/hooking/list-broadcast-receivers.js
+++ b/objection/hooks/android/hooking/list-broadcast-receivers.js
@@ -1,36 +1,27 @@
-// Lists the loaded classes that extend BroadcastReceiver available in the current Java
-// runtime.
+/**
+ * @summary Lists the registered BroadcastReceivers
+ * @author Bernard Wagner (@_dotvader)
+ */
+
 
 var BroadcastReceiver = Java.use('android.content.BroadcastReceiver');
 var ActivityThread = Java.use('android.app.ActivityThread');
+var ArrayMap = Java.use("android.util.ArrayMap");
 
 var currentApplication = ActivityThread.currentApplication();
 var context = currentApplication.getApplicationContext();
 
-var classes = Java.enumerateLoadedClassesSync();
+var receivers = []
 
-var receivers = classes.filter(function (className) {
-    //Exclude some classes to prevent Java.use blocking (Some memory management issue)
-    if (className.startsWith('android') || className.startsWith('java') || className.startsWith('com.android') || !className.includes('.')) return false;
-
-    //Some classes are not in search path resulting in Java.use throwing exception
-    try {
-        var clazz = Java.use(className);
-        var isReceiver = BroadcastReceiver.class.isAssignableFrom(clazz.class);
-        clazz.$dispose();
-        return isReceiver;
-    } catch (e) { }
-    return false;
+currentApplication.mLoadedApk['value'].mReceivers['value'].values().toArray().map(function(arrayMap){
+    Java.cast(arrayMap,ArrayMap).keySet().toArray().map(function(receiver){
+        receivers.push(receiver.$className)
+    });
 });
 
 receivers = receivers.concat(context.getPackageManager().getPackageInfo(context.getPackageName(), 0x00000002).receivers['value'].map(function (activity_info) {
     return activity_info.name['value'];
 }));
-
-//Unique, will create duplicates if receiver in Manifest has been triggered by a broadcast
-receivers = receivers.filter(function (elem, pos) {
-    return receivers.indexOf(elem) == pos;
-});
 
 var response = {
     status: 'success',


### PR DESCRIPTION
Rewrote module to make use of LoadedApk to list all registered BroadcastReceivers, opposed to inspecting the heap. Big performance improvement and more stable (enumerateLoadedClassesSync tends to crash after repeated calls).

Also fixes the module listing the super classes of registered receivers. 