### PR TITLE
Replaced delegator.run('which') with shutil.which() (python 3.3+)

### DIFF
--- a/objection/utils/packages.py
+++ b/objection/utils/packages.py
@@ -165,7 +165,7 @@ class BasePlatformPatcher(object):
 
         for cmd, attributes in self.required_commands.items():
 
-            location = delegator.run('which {0}'.format(cmd)).out.strip()
+            location = shutil.which(cmd)
 
             if len(location) <= 0:
                 click.secho('Unable to find {0}. Install it with: {1} before continuing.'.format(

--- a/objection/utils/packages.py
+++ b/objection/utils/packages.py
@@ -167,7 +167,7 @@ class BasePlatformPatcher(object):
 
             location = shutil.which(cmd)
 
-            if len(location) <= 0:
+            if location is None:
                 click.secho('Unable to find {0}. Install it with: {1} before continuing.'.format(
                     cmd, attributes['installation']), fg='red', bold=True)
 


### PR DESCRIPTION
delegator.run('which'...) doesn't work on Windows unless you have a modified command-line environment. Python's shutil.which() should provide the same functionality, cross-platform.