### PR TITLE
Added: android ui screenshot

### DIFF
--- a/objection/commands/ui.py
+++ b/objection/commands/ui.py
@@ -1,8 +1,9 @@
+import base64
 import click
 
 from ..state.device import device_state
 from ..utils.frida_transport import FridaRunner
-from ..utils.templates import ios_hook
+from ..utils.templates import ios_hook, android_hook
 
 
 def alert(args: list = None) -> None:
@@ -107,3 +108,34 @@ def bypass_touchid(args: list = None) -> None:
 
     runner = FridaRunner(hook=hook)
     runner.run_as_job(name='touchid-bypass')
+
+
+def android_screenshot(args: list = None) -> None:
+    """
+        Take an Android screenshot.
+
+        :param args:
+        :return:
+    """
+
+    if len(args) <= 0:
+        click.secho('Usage: android ui screenshot <local png destination>', bold=True)
+        return
+
+    destination = args[0]
+
+    hook = android_hook('screenshot/take')
+
+    runner = FridaRunner(hook=hook)
+    runner.run()
+
+    response = runner.get_last_message()
+
+    if not response.is_successful():
+        click.secho('Failed to screenshot with error: {0}'.format(response.error_reason), fg='red')
+        return
+
+    with open(destination, 'wb') as f:
+        f.write(base64.b64decode(response.data))
+
+    click.secho('Screenshot saved to: {0}'.format(destination), fg='green')

--- a/objection/commands/ui.py
+++ b/objection/commands/ui.py
@@ -127,15 +127,23 @@ def android_screenshot(args: list = None) -> None:
     hook = android_hook('screenshot/take')
 
     runner = FridaRunner(hook=hook)
-    runner.run()
+ 
+    api = runner.rpc_exports()
 
-    response = runner.get_last_message()
+    # download the file
+    data = api.screenshot()
 
-    if not response.is_successful():
-        click.secho('Failed to screenshot with error: {0}'.format(response.error_reason), fg='red')
+    # cleanup the runner
+    runner.unload_script()
+
+    if not data:
+        click.secho('Failed to take screenshot')
         return
 
+    image = bytearray(map(lambda x: x % 256, data))
+
     with open(destination, 'wb') as f:
-        f.write(base64.b64decode(response.data))
+        f.write(image)
 
     click.secho('Screenshot saved to: {0}'.format(destination), fg='green')
+

--- a/objection/console/commands.py
+++ b/objection/console/commands.py
@@ -298,7 +298,16 @@ COMMANDS = {
                         'exec': android_pinning.android_disable
                     }
                 }
-            }
+            },
+            'ui': {
+                'meta': 'Android user interface commands',
+                'commands': {
+                    'screenshot': {
+                        'meta': 'Screenshot the current Activity',
+                        'exec': ui.android_screenshot
+                    },
+                }
+            },
         },
     },
 

--- a/objection/console/helpfiles/android.ui.screenshot.txt
+++ b/objection/console/helpfiles/android.ui.screenshot.txt
@@ -1,0 +1,8 @@
+Command: android ui screenshot
+
+Usage: android ui screenshot <local png destination>
+
+Screenshots the current foregrounded Activity and saves it as a PNG locally.
+
+Examples:
+    android ios ui screenshot screenshot.png

--- a/objection/hooks/android/screenshot/take.js
+++ b/objection/hooks/android/screenshot/take.js
@@ -1,0 +1,47 @@
+var WindowManager = Java.use("android.view.WindowManager");
+var ActivityThread = Java.use('android.app.ActivityThread');
+var Activity = Java.use("android.app.Activity");
+var ActivityClientRecord = Java.use("android.app.ActivityThread$ActivityClientRecord");
+var ArrayMap = Java.use('android.util.ArrayMap');
+var Bitmap = Java.use("android.graphics.Bitmap");
+var File = Java.use("java.io.File");
+var ByteArrayOutputStream = Java.use("java.io.ByteArrayOutputStream");
+var CompressFormat = Java.use("android.graphics.Bitmap$CompressFormat");
+var Base64 = Java.use('android.util.Base64');
+
+var activityThread = ActivityThread.currentActivityThread();
+var currentApplication = ActivityThread.currentApplication();
+var context = currentApplication.getApplicationContext();
+
+var activityRecords = activityThread.mActivities['value'].values().toArray().filter(function(activityRecord) {
+    return !Java.cast(activityRecord,ActivityClientRecord).paused['value'];
+});
+
+if (activityRecords.length > 0) {
+    var currentActivity = Java.cast(Java.cast(activityRecords[0],ActivityClientRecord).activity['value'],Activity);
+
+    if (currentActivity){
+        var view = currentActivity.getWindow().getDecorView().getRootView();
+        view.setDrawingCacheEnabled(true);
+        var bitmap = Bitmap.createBitmap(view.getDrawingCache());
+        view.setDrawingCacheEnabled(false);
+        var outputStream = ByteArrayOutputStream.$new();
+        bitmap.compress(CompressFormat.PNG['value'],100,outputStream); 
+        send(JSON.stringify({
+            status: 'success',
+            error_reason: NaN,
+            type: 'android-screenshot',
+            data: Base64.encodeToString(outputStream.toByteArray(),0)
+        }));      
+        return;
+    }
+} else {
+    send(JSON.stringify({
+        status: 'error',
+        error_reason: 'Could not find current Activity. Is the application in the foreground?',
+        type: 'android-screenshot',
+        data: NaN
+    }));  
+}
+
+


### PR DESCRIPTION
# Description #

Loops through Activities and finds the first one not in a paused state. Thereafter dumps the drawing cache of the Activity. Works even when FLAG_SECURE is set.

# Example # 

```
ubuntu@ubuntu-dev:~/workspace/objection$ python3 -m objection.console.cli --gadget jakhar.aseem.diva explore

     _     _         _   _
 ___| |_  |_|___ ___| |_|_|___ ___
| . | . | | | -_|  _|  _| | . |   |
|___|___|_| |___|___|_| |_|___|_|_|
        |___|(object)inject(ion) v1.0.2

     Runtime Mobile Exploration
        by: @leonjza from @sensepost

[tab] for command suggestions
GT-I9500 on (samsung: 5.0.1) [usb] # android ui screenshot /tmp/test.png
Screenshot saved to: /tmp/test.png
```

# Known issues #
* Doesn't screenshot correctly if a dialog is in the foreground.
* Base64 encoding of byte[] should not be necessary, but ran into problems using get_extra_data and raw byte[]
