### PR TITLE
Add HTTPOnly check to cookies

### DIFF
--- a/objection/commands/ios/cookies.py
+++ b/objection/commands/ios/cookies.py
@@ -39,7 +39,8 @@ def get(args: list = None) -> None:
             cookie['expiresDate'],
             cookie['domain'],
             cookie['path'],
-            cookie['isSecure']
+            cookie['isSecure'],
+            cookie['isHTTPOnly']
         ])
 
-    click.secho(tabulate(data, headers=['Name', 'Value', 'Expires', 'Domain', 'Path', 'Secure']), bold=True)
+    click.secho(tabulate(data, headers=['Name', 'Value', 'Expires', 'Domain', 'Path', 'Secure', 'HTTPOnly']), bold=True)

--- a/objection/hooks/ios/binarycookie/get.js
+++ b/objection/hooks/ios/binarycookie/get.js
@@ -26,7 +26,8 @@ if (cookieJar.count() > 0) {
             domain: cookie.domain().toString(),
             // partition: cookie.partition().toString(),
             path: cookie.path().toString(),
-            isSecure: cookie.isSecure().toString()
+            isSecure: cookie.isSecure().toString(),
+            isHTTPOnly: cookie.isHTTPOnly().toString()
         };
 
         cookies.push(cookie_data);


### PR DESCRIPTION
This adds support for `HTTPOnly` to the `ios cookies get` command. This was useful for me but probably for others too.

![http](https://user-images.githubusercontent.com/1312973/30476903-bc4d5652-9a0b-11e7-81f9-f5ccef94944d.png)
