### PR TITLE
Hex encoding for Python 3

### DIFF
--- a/objection/commands/memory.py
+++ b/objection/commands/memory.py
@@ -174,7 +174,7 @@ def find_pattern(args: list) -> None:
 
     # if we got a string as input, convert it to hex
     if _is_string_input(args):
-        pattern = ' '.join(x.encode('hex') for x in args[0])
+        pattern = ' '.join(hex(ord(x))[2:] for x in args[0])
     else:
         pattern = args[0]
 


### PR DESCRIPTION
The memory search command fails with newer versions of Python 3  when trying to convert a string to hex:

`Error: 'hex' is not a text encoding; use codecs.encode() to handle arbitrary codecs`

The encode("hex") function has been removed from the latest versions of Python 3. The two options are to either use binascii.hexlify() or to use hex(ord(x))[2:]

I elected for the latter to avoid importing another module. Let me know if you think this is acceptable. I just tested with a known string in memory and it worked fine.