### PR TITLE
Added: android ui FLAG_SECURE

### DIFF
--- a/objection/commands/ui.py
+++ b/objection/commands/ui.py
@@ -145,3 +145,28 @@ def android_screenshot(args: list = None) -> None:
         f.write(image)
 
     click.secho('Screenshot saved to: {0}'.format(destination), fg='green')
+
+def android_flag_secure(args: list = None) -> None:
+    """
+        Control FLAG_SECURE of the current Activity, allowing or disallowing
+        the use of hardware key combinations and screencap to take screenshots.
+
+        :param args:
+        :return:
+    """
+
+    if (len(args) <= 0 or (args[0] != 'true' and args[0] != 'false')):
+        click.secho('Usage: android ui FLAG_SECURE <true/false>', bold=True)
+        return
+    runner = FridaRunner()
+    runner.set_hook_with_data(android_hook('screenshot/flag-secure'), value=args[0])
+
+    runner.run()
+
+    response = runner.get_last_message()
+
+    if not response.is_successful():
+        click.secho('Failed to set FLAG_SECURE'.format(response.error_message), fg='red')
+        return
+
+    click.secho("Successfuly set FLAG_SECURE" if response.data else "Successfully removed FLAG_SECURE")

--- a/objection/console/commands.py
+++ b/objection/console/commands.py
@@ -343,6 +343,10 @@ COMMANDS = {
                         'meta': 'Screenshot the current Activity',
                         'exec': ui.android_screenshot
                     },
+                    'FLAG_SECURE': {
+                        'meta': 'Control FLAG_SECURE of the current Activity',
+                        'exec': ui.android_flag_secure
+                    },
                 }
             },
         },

--- a/objection/console/helpfiles/android.ui.FLAG_SECURE.txt
+++ b/objection/console/helpfiles/android.ui.FLAG_SECURE.txt
@@ -1,0 +1,8 @@
+Command: android ui FLAG_SECURE
+
+Usage: android ui FLAG_SECURE <true/false>
+
+Control FLAG_SECURE of the current Activity
+
+Examples:
+    android ui FLAG_SECURE false

--- a/objection/hooks/android/screenshot/flag-secure.js
+++ b/objection/hooks/android/screenshot/flag-secure.js
@@ -1,0 +1,40 @@
+const VALUE = {{ value }};
+
+const FLAG_SECURE = 0x00002000;
+
+const ActivityThread = Java.use('android.app.ActivityThread');
+const Activity = Java.use('android.app.Activity');
+const ActivityClientRecord = Java.use('android.app.ActivityThread$ActivityClientRecord');
+
+var activityThread = ActivityThread.currentActivityThread();
+var activityRecords = activityThread.mActivities['value'].values().toArray();
+
+var currentActivity;
+
+for (var i in activityRecords) {
+
+    var activityRecord = Java.cast(activityRecords[i], ActivityClientRecord);
+
+    if (!activityRecord.paused['value']) {
+        currentActivity = Java.cast(Java.cast(activityRecord, ActivityClientRecord)
+            .activity['value'], Activity);
+        break;
+    }
+}
+
+if (currentActivity){
+    // Somehow the next line prevents Frida from throwing an abort error
+    currentActivity.getWindow();
+
+    // Set flag and trigger update (Throws abort without first calling getWindow())
+    Java.scheduleOnMainThread(function(){
+
+        currentActivity.getWindow().setFlags(VALUE ? FLAG_SECURE : 0,FLAG_SECURE);
+    });
+    send(JSON.stringify({
+        status: 'success',
+        error_reason: NaN,
+        type: 'android-flag-secure',
+        data: VALUE
+    }));
+}


### PR DESCRIPTION
# Overview # 

Change FLAG_SECURE of the current Activity, so that screenshots can be taken. Does not invalidate use case for `android ui screenshot`, which downloads directly to host.

# Example # 
```
$ python3 -m objection.console.cli --gadget com.bw.testflagsecure explore

     _     _         _   _
 ___| |_  |_|___ ___| |_|_|___ ___
| . | . | | | -_|  _|  _| | . |   |
|___|___|_| |___|___|_| |_|___|_|_|
        |___|(object)inject(ion) v1.1.4

     Runtime Mobile Exploration
        by: @leonjza from @sensepost

[tab] for command suggestions
com.bw.testflagsecure on (google: 7.1.2) [usb] # android ui FLAG_SECURE false
Successfully removed FLAG_SECURE
com.bw.testflagsecure on (google: 7.1.2) [usb] #
```

```
adb pull /sdcard/Pictures/Screenshots/Screenshot_20170920-234544.png
/sdcard/Pictures/Screenshots/Screenshot_20170920-234544.png: 1 file pulled. 0.6 MB/s (34751 bytes in 0.056s)
```

# Testing # 

```
package com.bw.testflagsecure;

import android.support.v7.app.AppCompatActivity;
import android.os.Bundle;
import android.view.WindowManager;

public class MainActivity extends AppCompatActivity {

    @Override
    protected void onCreate(Bundle savedInstanceState) {
        getWindow().addFlags(WindowManager.LayoutParams.FLAG_SECURE);
        super.onCreate(savedInstanceState);
        setContentView(R.layout.activity_main);
    }
}
```

# Known Issues # 
* `SELinux` really dislikes `scheduleOnMainThread` on 32-bit devices. 
* Strange behaviour with `scheduleOnMainThread`, requires `getWindow()` to be called prior to calling `setFlags(int,int)`
