### PR TITLE
Added support for --host and --port options

### DIFF
--- a/objection/utils/frida_transport.py
+++ b/objection/utils/frida_transport.py
@@ -282,7 +282,12 @@ class FridaRunner(object):
             return frida.get_usb_device(5).attach(state_connection.gadget_name)
 
         if state_connection.get_comms_type() == state_connection.TYPE_REMOTE:
-            return frida.get_remote_device().attach(state_connection.gadget_name)
+            try:
+                device = frida.get_device("tcp@%s:%d" % (state_connection.host, state_connection.port))
+            except frida.TimedOutError as e:
+                device = frida.get_device_manager().add_remote_device("%s:%d" % (state_connection.host, state_connection.port))
+
+            return device.attach(state_connection.gadget_name)
 
     def set_hook_with_data(self, hook: str, **kwargs) -> None:
         """


### PR DESCRIPTION
The --host and --port options are not currently used. This patch allows objection to connect to the correct remote frida server.