### PR TITLE
Added arguments and return value print in android hooking method

### DIFF
--- a/objection/commands/android/hooking.py
+++ b/objection/commands/android/hooking.py
@@ -25,6 +25,16 @@ def _should_include_backtrace(args: list) -> bool:
 
     return '--include-backtrace' in args
 
+def _should_dump_args(args: list) -> bool:
+    """
+        Check if --dump-args is part of the arguments.
+
+        :param args:
+        :return:
+    """
+
+    return '--dump-args' in args
+
 
 def show_android_classes(args: list = None) -> None:
     """
@@ -102,7 +112,8 @@ def watch_class_method(args: list) -> None:
     runner = FridaRunner()
     runner.set_hook_with_data(android_hook('hooking/watch-method'),
                               target_class=target_class, target_method=target_method,
-                              include_backtrace=_should_include_backtrace(args))
+                              include_backtrace=_should_include_backtrace(args),
+                              dump_args=_should_dump_args(args))
 
     runner.run_as_job(name='watch-java-method')
 

--- a/objection/hooks/android/hooking/watch-method.js
+++ b/objection/hooks/android/hooking/watch-method.js
@@ -5,7 +5,7 @@
 var Throwable = Java.use('java.lang.Throwable');
 
 var target_class = Java.use('{{ target_class }}');
-var overload_count = eval('target_class.{{ target_method }}.overloads.length');
+var overload_count = target_class.{{ target_method }}.overloads.length;
 
 send({
     status: 'success',
@@ -25,19 +25,20 @@ for (var i = 0; i < overload_count; i++) {
     });
 
     // Hook the overload.
-    eval('target_class.{{ target_method }}.overloads[i]').implementation = function () {
+    target_class.{{ target_method }}.overloads[i].implementation = function () {
 
         var message = 'Called {{ target_class }}.{{ target_method }} (args: ' + arguments.length + ')';
 
         // if we should include a backtrace to here, do that.
-        if ('{{ include_backtrace }}' == 'True') {
+        {% if include_backtrace %}
 
             message += '\nBacktrace:\n\t' + Throwable.$new().getStackTrace()
                 .map(function (stack_trace_element) {
 
                     return stack_trace_element.toString() + '\n\t';
                 }).join('');
-        }
+
+        {% endif %}
 
         send({
             status: 'success',
@@ -46,7 +47,32 @@ for (var i = 0; i < overload_count; i++) {
             data: message
         });
 
+        {% if dump_args %}
+            // Loop the arguments and dump the values.toString()
+            for (var h = 0; h < arguments.length; h++) {
+
+                send({
+                    status: 'success',
+                    error_reason: NaN,
+                    type: 'watch-class-method',
+                    data: '{{ target_method }} - Arg ' + h + ': ' + arguments[h].toString()
+                });
+            }
+        {% endif %}
+
+
         // continue with the original method
-        return eval('this.{{ target_method }}.apply(this, arguments)');
+        var ret = this.{{ target_method }}.apply(this, arguments);
+        {% if dump_args %}
+            send({
+                status: 'success',
+                error_reason: NaN,
+                type: 'watch-class-method',
+                data: '{{ target_method }} - Returned : ' + ret.toString()
+            });
+        {% endif %}
+
+        return ret;
+
     }
 }


### PR DESCRIPTION
This patch add a --dump-args option to the android hooking command. It will print the arguments and the return value when the method is actually executed.