### PR TITLE
Support spawning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,9 @@ __pycache__/
 # Distribution / packaging
 .Python
 env/
+bin/
 build/
+include/
 develop-eggs/
 dist/
 downloads/
@@ -31,6 +33,7 @@ sdist/
 # Installer logs
 pip-log.txt
 pip-delete-this-directory.txt
+pip-selfcheck.json
 
 # Unit test / coverage reports
 htmlcov/

--- a/objection/console/cli.py
+++ b/objection/console/cli.py
@@ -63,6 +63,10 @@ def explore(startup_command: str, startup_script: str, hook_debug: bool, quiet: 
 
     # specify if hooks should be debugged
     app_state.debug_hooks = hook_debug
+    try:
+        pid = state_connection.get_pid()
+    except:
+        state_connection.spawn()    
 
     # start the main REPL
     r = Repl()
@@ -79,6 +83,8 @@ def explore(startup_command: str, startup_script: str, hook_debug: bool, quiet: 
     if startup_script:
         click.secho('Importing and running a startup script...', dim=True)
         r.run_command('import {0}'.format(startup_script))
+    
+    state_connection.resume()
 
     try:
 

--- a/objection/utils/frida_transport.py
+++ b/objection/utils/frida_transport.py
@@ -277,17 +277,7 @@ class FridaRunner(object):
             Attempt to get a Frida session.
         """
 
-        if state_connection.get_comms_type() == state_connection.TYPE_USB:
-            return frida.get_usb_device(5).attach(state_connection.gadget_name)
-
-        if state_connection.get_comms_type() == state_connection.TYPE_REMOTE:
-            try:
-                device = frida.get_device("tcp@%s:%d" % (state_connection.host, state_connection.port))
-            except frida.TimedOutError:
-                device = frida.get_device_manager().add_remote_device(
-                    "%s:%d" % (state_connection.host, state_connection.port))
-
-            return device.attach(state_connection.gadget_name)
+        return state_connection.get_device().attach(state_connection.gadget_name)
 
     def set_hook_with_data(self, hook: str, **kwargs) -> None:
         """


### PR DESCRIPTION
Finally got around to implementing spawning which resolves #15 , but it still needs to be thoroughly tested. Wanted to get your input so long on the approach and initial testing.

Current flow is that it checks whether a process with the Gadget name exists, otherwise it assumes you want to spawn. Will then run all the startup_commands and startup_scripts before resuming the main thread. 

```
(objection) bw-mac:objection bw$ python -m objection.console.cli --gadget com.highaltitudehacks.dvia explore --startup-command 'ios jailbreak disable'
Running a startup command... ios jailbreak disable
Job: 1eefd29e-e6cc-4940-8388-e68a6c3e32a1 - Starting
Job: 1eefd29e-e6cc-4940-8388-e68a6c3e32a1 - Started

     _     _         _   _
 ___| |_  |_|___ ___| |_|_|___ ___
| . | . | | | -_|  _|  _| | . |   |
|___|___|_| |___|___|_| |_|___|_|_|
        |___|(object)inject(ion) v1.2.3

     Runtime Mobile Exploration
        by: @leonjza from @sensepost

[tab] for command suggestions
com.highaltitudehacks.dvia on (iPhone: 10.1.1) [usb] # jobs list
UUID                                  Name                         Started              Arguments
------------------------------------  ---------------------------  -------------------  -----------
1eefd29e-e6cc-4940-8388-e68a6c3e32a1  disable-jailbreak-detection  2018-01-22 19:54:41  n/a
com.highaltitudehacks.dvia on (iPhone: 10.1.1) [usb] # [e68a6c3e32a1] [jailbreak-bypass] A successful lookup for /Applications/Cydia.
app occurred. Marking it as failed.
[e68a6c3e32a1] [jailbreak-bypass] A successful lookup for /bin/bash occurred. Marking it as failed.
[e68a6c3e32a1] [jailbreak-bypass] A successful lookup for /etc/apt occurred. Marking it as failed.
```

