### PR TITLE
Fix for android class watcher

### DIFF
--- a/objection/hooks/android/hooking/watch-class-methods.js
+++ b/objection/hooks/android/hooking/watch-class-methods.js
@@ -12,9 +12,12 @@ var methods = target_class.class.getDeclaredMethods().map(function (method) {
 
     // eg: public void com.example.fooBar(int,int)
     var full_method_signature = method.toGenericString();
+	if (full_method_signature.indexOf('throws') !== -1) {
+		full_method_signature = full_method_signature.substring(0, full_method_signature.indexOf('throws') - 1);
+	}
 
     // remove the scope and return type
-    var method_only_delimiter_location = full_method_signature.lastIndexOf(' ');
+	var method_only_delimiter_location = full_method_signature.lastIndexOf(' ');
     var class_and_method_name = full_method_signature.slice(method_only_delimiter_location)
 
     // remove the classname
@@ -34,7 +37,7 @@ send({
     status: 'success',
     error_reason: NaN,
     type: 'watch-class',
-    data: 'Found class with ' + methods.length + ' methods (excl: overloads)',
+    data: 'Found class with ' + methods.length + ' methods (excl: overloads), methods = ' + methods.toString(),
 });
 
 for (var m = 0; m < methods.length; m++) {

--- a/objection/hooks/android/hooking/watch-class-methods.js
+++ b/objection/hooks/android/hooking/watch-class-methods.js
@@ -12,8 +12,8 @@ var methods = target_class.class.getDeclaredMethods().map(function (method) {
 
     // eg: public void com.example.fooBar(int,int)
     var full_method_signature = method.toGenericString();
-    if (full_method_signature.indexOf('throws') !== -1) {
-        full_method_signature = full_method_signature.substring(0, full_method_signature.indexOf('throws') - 1);
+    if (full_method_signature.indexOf(' throws ') !== -1) {
+        full_method_signature = full_method_signature.substring(0, full_method_signature.indexOf(' throws '));
     }
 
     // remove the scope and return type
@@ -113,4 +113,3 @@ for (var m = 0; m < methods.length; m++) {
         }
     }
 }
-

--- a/objection/hooks/android/hooking/watch-class-methods.js
+++ b/objection/hooks/android/hooking/watch-class-methods.js
@@ -12,12 +12,12 @@ var methods = target_class.class.getDeclaredMethods().map(function (method) {
 
     // eg: public void com.example.fooBar(int,int)
     var full_method_signature = method.toGenericString();
-	if (full_method_signature.indexOf('throws') !== -1) {
-		full_method_signature = full_method_signature.substring(0, full_method_signature.indexOf('throws') - 1);
-	}
+    if (full_method_signature.indexOf('throws') !== -1) {
+        full_method_signature = full_method_signature.substring(0, full_method_signature.indexOf('throws') - 1);
+    }
 
     // remove the scope and return type
-	var method_only_delimiter_location = full_method_signature.lastIndexOf(' ');
+    var method_only_delimiter_location = full_method_signature.lastIndexOf(' ');
     var class_and_method_name = full_method_signature.slice(method_only_delimiter_location)
 
     // remove the classname
@@ -37,7 +37,7 @@ send({
     status: 'success',
     error_reason: NaN,
     type: 'watch-class',
-    data: 'Found class with ' + methods.length + ' methods (excl: overloads), methods = ' + methods.toString(),
+    data: 'Found class with ' + methods.length + ' methods (excl: overloads)',
 });
 
 for (var m = 0; m < methods.length; m++) {
@@ -113,3 +113,4 @@ for (var m = 0; m < methods.length; m++) {
         }
     }
 }
+


### PR DESCRIPTION
The current android class watcher does splits on the space character to extract the method name from the method signature.
However, the method signature can contain " throws Exception" at the end of the signature, resulting in a wrong method name that triggers the error "cannot read property 'overloads' of undefine" later in the code:
```javascript
var overload_count = target_class[target_method].overloads.length;
```

This PR remove the " throws Exception" part if there is a throws statement.