### PR TITLE
Set prompt_toolkit version. (2.0.0 has breaking changes).

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 frida
-prompt_toolkit
+prompt_toolkit>=1.0.15,<2.0.0
 click
 jinja2
 tabulate


### PR DESCRIPTION
I will probably release prompt_toolkit 2.0 this or next week, and it has breaking changes, so it'd be good to merge this. After the release we can still upgrade.