### PR TITLE
Fix for Windows os-dependent path

### DIFF
--- a/objection/commands/filemanager.py
+++ b/objection/commands/filemanager.py
@@ -17,6 +17,7 @@ from ..utils.templates import ios_hook, android_hook
 _ls_cache = {}
 
 
+
 def cd(args: list) -> None:
     """
         Change the current working directory of the device.
@@ -45,8 +46,7 @@ def cd(args: list) -> None:
         return
 
     # moving one directory back
-    if path == '..':
-
+    if path == "..":
         split_path = os.path.split(current_dir)
 
         # nothing to do if we are already at root
@@ -88,9 +88,10 @@ def cd(args: list) -> None:
 
     # directory is not absolute, tack it on at the end and
     # see if its legit.
+    
     else:
 
-        proposed_path = os.path.join(current_dir, path)
+        proposed_path = "/".join([current_dir, path])
 
         # assume the proposed_path does not exist by default
         does_exist = False
@@ -112,7 +113,7 @@ def cd(args: list) -> None:
             return
 
         else:
-            click.secho('Invalid path: `{0}`'.format(proposed_path), fg='red')
+            click.secho('Invalid patha: `{0}`'.format(proposed_path), fg='red')
 
 
 def _path_exists_ios(path: str) -> bool:
@@ -147,8 +148,8 @@ def _path_exists_android(path: str) -> bool:
     runner.run()
 
     return runner.get_last_message().exists
-
-
+    
+    
 def pwd(args: list = None) -> str:
     """
         Return the current working directory.
@@ -478,7 +479,7 @@ def _download_ios(path: str, destination: str) -> None:
     # if the path we got is not absolute, join it with the
     # current working directory
     if not os.path.isabs(path):
-        path = os.path.join(pwd(), path)
+        path = "/".join([pwd(), path])
 
     # output about whats about to happen
     click.secho('Downloading {0} to {1}'.format(path, destination), fg='green', dim=True)
@@ -544,7 +545,7 @@ def _download_android(path: str, destination: str) -> None:
     # if the path we got is not absolute, join it with the
     # current working directory
     if not os.path.isabs(path):
-        path = os.path.join(pwd(), path)
+        path = "/".join([pwd(), path])
 
     # output about whats about to happen
     click.secho('Downloading {0} to {1}'.format(path, destination), fg='green', dim=True)
@@ -616,7 +617,7 @@ def upload(args: list) -> None:
         return
 
     source = args[0]
-    destination = args[1] if len(args) > 1 else os.path.join(pwd(), os.path.basename(source))
+    destination = args[1] if len(args) > 1 else "/".join([pwd(), os.path.basename(source)])
 
     if device_state.device_type == 'ios':
         _upload_ios(source, destination)
@@ -635,7 +636,7 @@ def _upload_ios(path: str, destination: str) -> None:
     """
 
     if not os.path.isabs(destination):
-        destination = os.path.join(pwd(), destination)
+        destination = "/".join([pwd(), destination])
 
     # output about whats about to happen
     click.secho('Uploading {0} to {1}'.format(path, destination), fg='green', dim=True)
@@ -690,7 +691,7 @@ def _upload_android(path: str, destination: str) -> None:
     """
 
     if not os.path.isabs(destination):
-        destination = os.path.join(pwd(), destination)
+        destination = "/".join([pwd(), destination])
 
     # output about whats about to happen
     click.secho('Uploading {0} to {1}'.format(path, destination), fg='green', dim=True)

--- a/objection/commands/filemanager.py
+++ b/objection/commands/filemanager.py
@@ -46,19 +46,26 @@ def cd(args: list) -> None:
         return
 
     # moving one directory back
-    if path == "..":
-        split_path = os.path.split(current_dir)
+    if ".." in path:
+        if path == ".." or path == "../":
+            split_path = os.path.split(current_dir)
 
-        # nothing to do if we are already at root
-        if len(split_path) == 1:
+            # nothing to do if we are already at root
+            if len(split_path) == 1:
+                return
+
+            new_path = ''.join(split_path[:-1])
+            click.secho(new_path, fg='green', bold=True)
+
+            file_manager_state.cwd = new_path
+
             return
 
-        new_path = ''.join(split_path[:-1])
-        click.secho(new_path, fg='green', bold=True)
-
-        file_manager_state.cwd = new_path
-
-        return
+        #if path contains ".." as a substring
+        else:
+            click.secho('Invalid path: `{0}`'.format(path), fg='red')
+            click.secho('Path must not contains ".." ', fg='red')
+            return
 
     # if we got an absolute path, check if the path
     # actually exists, and then cd to it if we can


### PR DESCRIPTION
Hi!

I did not found any PR policy so swear i'm not doing wrong.
Here are two commits for two bugs:
 - The first is related with issue #165. As os.path.join were used in filemanager.py, when running on Windows it join the strings with Windows separator "\". As these paths are applied to frida environment running on Android or iOS, they uses Posix separators, so always "/" is used then.
 - The second is when a path contains ".." (in example: "../cache"). After accessing it (succesfull) the code stores the same string (with the ".." not resolved) on the "file_manager_state.cwd" so following actions involving paths will fail.

Regards,
Javier.