### PR TITLE
Error checking during rebuildapk when an Internet permission injectio…

### DIFF
--- a/objection/commands/mobile_packages.py
+++ b/objection/commands/mobile_packages.py
@@ -150,7 +150,7 @@ def patch_android_apk(source: str, architecture: str, pause: bool, skip_cleanup:
     # work on patching the APK
     patcher.set_apk_source(source=source)
     patcher.unpack_apk(skip_resources=skip_resources)
-    patcher.inject_internet_permission()
+    patcher.inject_internet_permission(skip_resources=skip_resources)
 
     if enable_debug:
         patcher.flip_debug_flag_to_true()

--- a/objection/utils/patchers/android.py
+++ b/objection/utils/patchers/android.py
@@ -363,7 +363,7 @@ class AndroidPatcher(BasePlatformPatcher):
             click.secho('An error may have occured while extracting the APK.', fg='red')
             click.secho(o.err, fg='red')
 
-    def inject_internet_permission(self):
+    def inject_internet_permission(self, skip_resources: bool = False):
         """
             Checks the status of the source APK to see if it
             has the INTERNET permission. If not, the manifest file
@@ -378,6 +378,11 @@ class AndroidPatcher(BasePlatformPatcher):
         if internet_permission in self._get_appt_output():
             click.secho('App already has android.permission.INTERNET', fg='green')
             return
+
+        # if not, error if --skip-resources was used because the manifest is encoded
+        elif skip_resources is True:
+            click.secho('Cannot patch an APK for Internet permission when --skip-resources is set, remove this and try again.', fg='red')
+            raise Exception('Cannot --skip-resources with no Internet permission')
 
         # if not, we need to inject an element with it
         xml = self._get_android_manifest()


### PR DESCRIPTION
Duplicate of a merged master PR as requested in #168

----
rebuildapk will currently fail on an app without Internet permission when running with --skip-resources. This is because the manifest has to be decoded to insert the Internet permission.

The code currently allows a user to attempt the injection anyway, which causes a vague xml.etree.ElementTree.ParseError: not well-formed (invalid token): line 1, column 0 exception.

This may be related to #157