### PR TITLE
Fix iOS hooking return value checks

### DIFF
--- a/tests/commands/test_memory.py
+++ b/tests/commands/test_memory.py
@@ -43,6 +43,7 @@ class TestMemory(unittest.TestCase):
             output = o
 
         expected_output = """Will dump 1 rw- images, totalling 100.0 B
+
 Memory dumped to file: /foo
 """
 

--- a/tests/utils/test_agent.py
+++ b/tests/utils/test_agent.py
@@ -1,0 +1,35 @@
+import unittest
+from unittest import mock
+
+from objection.utils.agent import Agent
+
+
+class TestAgent(unittest.TestCase):
+    @mock.patch('objection.utils.agent.app_state')
+    def test_agent_loads_from_disk_successfully_without_debug(self, mock_app_state):
+        mock_app_state.should_debug.return_value = False
+
+        agent = Agent()
+        source = agent._get_agent_source()
+
+        self.assertTrue(mock_app_state.should_debug.called)
+        self.assertTrue('rpc.exports' in source)
+
+    @mock.patch('objection.utils.agent.app_state')
+    def test_agent_loads_from_disk_successfully_with_debug(self, mock_app_state):
+        mock_app_state.should_debug.return_value = True
+
+        agent = Agent()
+        source = agent._get_agent_source()
+
+        self.assertTrue(mock_app_state.should_debug.called)
+        self.assertTrue('rpc.exports' in source)
+        self.assertTrue('application/json;charset=utf-8;base64' in source.split(':')[-1])
+
+    @mock.patch('objection.utils.agent.os')
+    def test_agent_fails_to_load_throws_error(self, mock_os):
+        mock_os.path.exists.return_value = False
+
+        with self.assertRaises(Exception) as _:
+            agent = Agent()
+            agent._get_agent_source()


### PR DESCRIPTION
Fixes typo in `hooking.ts` for iOS. 

Fixes #193.