### PR TITLE
minor refactoring of github class for better readability

### DIFF
--- a/objection/commands/mobile_packages.py
+++ b/objection/commands/mobile_packages.py
@@ -34,7 +34,7 @@ def patch_ios_ipa(source: str, codesign_signature: str, provision_file: str, bin
         github_version = gadget_version
         click.secho('Using manually specified version: {0}'.format(gadget_version), fg='green', bold=True)
     else:
-        github_version = github.set_latest_version()
+        github_version = github.get_latest_version()
         click.secho('Using latest Github gadget version: {0}'.format(github_version), fg='green', bold=True)
 
     # get the local version number of the stored gadget
@@ -119,7 +119,7 @@ def patch_android_apk(source: str, architecture: str, pause: bool, skip_cleanup:
         github_version = gadget_version
         click.secho('Using manually specified version: {0}'.format(gadget_version), fg='green', bold=True)
     else:
-        github_version = github.set_latest_version()
+        github_version = github.get_latest_version()
         click.secho('Using latest Github gadget version: {0}'.format(github_version), fg='green', bold=True)
 
     # get local version of the stored gadget

--- a/objection/utils/patchers/github.py
+++ b/objection/utils/patchers/github.py
@@ -41,7 +41,7 @@ class Github(object):
         # and return it
         return results
 
-    def set_latest_version(self) -> str:
+    def get_latest_version(self) -> str:
         """
             Call Github and get the tag_name of the latest
             release.

--- a/tests/commands/test_mobile_packages.py
+++ b/tests/commands/test_mobile_packages.py
@@ -12,7 +12,7 @@ class TestMobilePackages(unittest.TestCase):
     @mock.patch('objection.commands.mobile_packages.shutil')
     @mock.patch('objection.commands.mobile_packages.os')
     def test_patching_ios_ipa(self, mock_os, mock_shutil, mock_iospatcher, mock_iosgadget, mock_github):
-        mock_github.return_value.set_latest_version.return_value = '1.0'
+        mock_github.return_value.get_latest_version.return_value = '1.0'
         mock_iosgadget.return_value.get_local_version.return_value = '0.9'
 
         mock_iospatcher.return_value.are_requirements_met.return_value = True
@@ -42,7 +42,7 @@ Copying final ipa from /foo/ipa to current directory...
     @mock.patch('objection.commands.mobile_packages.input', create=True)
     def test_patching_android_apk(self, mock_input, mock_delegator, mock_os, mock_shutil, mock_androidpatcher,
                                   mock_androidgadget, mock_github):
-        mock_github.return_value.set_latest_version.return_value = '1.0'
+        mock_github.return_value.get_latest_version.return_value = '1.0'
         mock_androidgadget.return_value.get_local_version.return_value = '0.9'
 
         mock_androidpatcher.return_value.are_requirements_met.return_value = True

--- a/tests/utils/patchers/test_github.py
+++ b/tests/utils/patchers/test_github.py
@@ -71,7 +71,7 @@ class TestGithub(unittest.TestCase):
 
         mock_requests.get.return_value = mock_response
 
-        result = self.github.set_latest_version()
+        result = self.github.get_latest_version()
 
         self.assertEqual(result, self.mock_response['tag_name'])
 


### PR DESCRIPTION
the function "set_latest_version" is named as a setter, while the function more directly acts as a getter. This PR refactors the function to "get_latest_version".