### PR TITLE
add ability to output memory exports and memory modules to json

### DIFF
--- a/objection/console/commands.py
+++ b/objection/console/commands.py
@@ -162,11 +162,13 @@ COMMANDS = {
                 'commands': {
                     'modules': {
                         'meta': 'List loaded modules in the current process',
+                        'flags': ['--json'],
                         'exec': memory.list_modules
                     },
 
                     'exports': {
                         'meta': 'List the exports of a module',
+                        'flags': ['--json'],
                         'exec': memory.list_exports
                     }
                 },
@@ -426,7 +428,7 @@ COMMANDS = {
                         'exec': keychain.dump
                     },
                     'clear': {
-                        'meta': 'Delete all keychain entries for the current app\s entitlement group',
+                        'meta': 'Delete all keychain entries for the current app\'s entitlement group',
                         'exec': keychain.clear
                     },
                     'add': {

--- a/objection/console/helpfiles/memory.list.exports.txt
+++ b/objection/console/helpfiles/memory.list.exports.txt
@@ -1,6 +1,6 @@
 Command: memory list exports
 
-Usage: memory list exports <module name>
+Usage: memory list exports <module name> (optional: --json <filename>)
 
 List exports in a specific loaded module. Exports found using this command
 could be used in Fridascripts to hook with module.findExportByName().
@@ -10,3 +10,4 @@ may be used.
 Examples:
    memory list exports libsystem_configuration.dylib
    memory list exports UserManagement
+   memory list exports UserManagement --json UserManagementExports.json

--- a/objection/console/helpfiles/memory.list.modules.txt
+++ b/objection/console/helpfiles/memory.list.modules.txt
@@ -1,9 +1,12 @@
 Command: memory list modules
 
-Usage: memory list modules
+Usage: memory list modules (optional: --json <filename>)
 
 List all of the modules loaded in the current process, detailing their base
 address, size and location on disk.
+Providing a filename with the --json flag will output all of the module
+attributes to the file specified for later inspection.
 
 Examples:
    memory list modules
+   memory list modules --json modules.json


### PR DESCRIPTION
This allows a user to export the memory exports and memory modules in json format. This is especially important when running `memory list modules`, as the fixed column width can truncate the "path" field.