### PR TITLE
Fix spawned iOS processes

### DIFF
--- a/objection/utils/agent.py
+++ b/objection/utils/agent.py
@@ -159,7 +159,7 @@ class Agent(object):
         self.spawned_pid = self.device.spawn(state_connection.gadget_name)
         debug_print('PID `{pid}` spawned, attaching...'.format(pid=self.spawned_pid))
 
-        self.session = self.device.attach(state_connection.gadget_name)
+        self.session = self.device.attach(self.spawned_pid)
         return self.session
 
     def _get_agent_source(self) -> str:


### PR DESCRIPTION
Replaces references in agent.py after spawning a process to use the PID instead of process name.

Fixes #224.