### PR TITLE
Fix duplicate entries in android manifest file

### DIFF
--- a/objection/utils/patchers/android.py
+++ b/objection/utils/patchers/android.py
@@ -430,7 +430,7 @@ class AndroidPatcher(BasePlatformPatcher):
             return
 
         # set the debuggable flag
-        application_tag.attrib['android:debuggable'] = 'true'
+        application_tag.attrib['{http://schemas.android.com/apk/res/android}debuggable'] = 'true'
 
         click.secho('Writing new Android manifest...', dim=True)
         xml.write(os.path.join(self.apk_temp_directory, 'AndroidManifest.xml'),

--- a/objection/utils/patchers/android.py
+++ b/objection/utils/patchers/android.py
@@ -484,7 +484,7 @@ class AndroidPatcher(BasePlatformPatcher):
 
         # set the networkSecurityConfig xml location
         # this is in res/xml/network_security_config.xml
-        application_tag.attrib['android:networkSecurityConfig'] = '@xml/network_security_config'
+        application_tag.attrib['{http://schemas.android.com/apk/res/android}networkSecurityConfig'] = '@xml/network_security_config'
 
         click.secho('Writing new Android manifest...', dim=True)
         xml.write(os.path.join(self.apk_temp_directory, 'AndroidManifest.xml'),


### PR DESCRIPTION
This is the error when `objection patchapk -s <apk> -d -N ` is used. In this case it fails when it tries to update the debug flag attribute:

```bash
...
App already has android.permission.INTERNET
Setting debug flag to true
Writing new Android manifest...
Traceback (most recent call last):
  File "/usr/local/bin/objection", line 10, in <module>
    sys.exit(cli())
  File "/usr/local/lib/python3.7/dist-packages/click/core.py", line 764, in __call__
    return self.main(*args, **kwargs)
  File "/usr/local/lib/python3.7/dist-packages/click/core.py", line 717, in main
    rv = self.invoke(ctx)
  File "/usr/local/lib/python3.7/dist-packages/click/core.py", line 1137, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/usr/local/lib/python3.7/dist-packages/click/core.py", line 956, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/usr/local/lib/python3.7/dist-packages/click/core.py", line 555, in invoke
    return callback(*args, **kwargs)
  File "/usr/local/lib/python3.7/dist-packages/objection/console/cli.py", line 342, in patchapk
    patch_android_apk(**locals())
  File "/usr/local/lib/python3.7/dist-packages/objection/commands/mobile_packages.py", line 159, in patch_android_apk
    patcher.add_network_security_config()
  File "/usr/local/lib/python3.7/dist-packages/objection/utils/patchers/android.py", line 458, in add_network_security_config
    xml = self._get_android_manifest()
  File "/usr/local/lib/python3.7/dist-packages/objection/utils/patchers/android.py", line 239, in _get_android_manifest
    return ElementTree.parse(os.path.join(self.apk_temp_directory, 'AndroidManifest.xml'))
  File "/usr/lib/python3.7/xml/etree/ElementTree.py", line 1197, in parse
    tree.parse(source, parser)
  File "/usr/lib/python3.7/xml/etree/ElementTree.py", line 598, in parse
    self._root = parser._parse_whole(source)
xml.etree.ElementTree.ParseError: duplicate attribute: line 11, column 70
Cleaning up temp files...
...
```

The error is a duplicate attribute in the AndroidManifest.xml file, after "changing" the debug flag to true.

The debug attribbute is being set at the following snippet in L433:

https://github.com/sensepost/objection/blob/33f787fe2be26b0af8c7a8f7c057b85f2e8620f3/objection/utils/patchers/android.py#L433

With some debug code this is the output of the attributes before and after the above line of code:

```bash
# before
{http://schemas.android.com/apk/res/android}allowBackup
{http://schemas.android.com/apk/res/android}debuggable
{http://schemas.android.com/apk/res/android}icon
{http://schemas.android.com/apk/res/android}label
{http://schemas.android.com/apk/res/android}name

# after
{http://schemas.android.com/apk/res/android}allowBackup
{http://schemas.android.com/apk/res/android}debuggable
{http://schemas.android.com/apk/res/android}icon
{http://schemas.android.com/apk/res/android}label
{http://schemas.android.com/apk/res/android}name
android:debuggable
```

The line of code is creating a new debuggable entry, which causes the error as seen above.

This only happens when you have an AndroidManifest file with android:debuggable="false". Most of the time it is not present or set to true, in which case it won't fail.

The same issue occur when the network_security_config.xml exists:
```bash
...
App already has android.permission.INTERNET
Setting debug flag to true
Application already has the android:debuggable flag set to True
Checking for an existing networkSecurityConfig tag
An existing network security config was found. Do you want to replace it? [True]: 
Copying network_security_config.xml...
Writing new Android manifest...
Target class not specified, searching for launchable activity instead...
...
Copying Frida gadget to libs path...
Rebuilding the APK with the frida-gadget loaded...
Rebuilding the APK may have failed. Read the following output to determine if apktool actually had an error: 
Fatal Error] :17:289: Attribute "android:networkSecurityConfig" was already specified for element "application".
```

The issue is with the following line of code:
https://github.com/sensepost/objection/blob/33f787fe2be26b0af8c7a8f7c057b85f2e8620f3/objection/utils/patchers/android.py#L487

