### PR TITLE
Fixed iOS bytesToHexString

### DIFF
--- a/agent/src/ios/lib/helpers.ts
+++ b/agent/src/ios/lib/helpers.ts
@@ -117,7 +117,7 @@ export const bytesToUTF8 = (data: any): string => {
 export const bytesToHexString = (data: any): string => {
   // https://stackoverflow.com/a/50767210
   const buffer: ArrayBuffer = data.bytes().readByteArray(data.length());
-  return Array.from(new Uint8Array(buffer)).map((b) => b.toString(16)).join("");
+  return Array.from(new Uint8Array(buffer)).map((b) => ("0" + b.toString(16)).substr(-2)).join("");
 };
 
 export const getNSFileManager = (): NSFileManager => {


### PR DESCRIPTION
In the current version of ```bytesToHexString, b.toString(16)``` is used to convert bytes to hex. However, if the current byte is lower than 0x10, it will be returned on 1 char instead of 2 as we would expect.

The problem was identified when dumping iOS keychain and resulting in a odd-length hex string.

As duktape does not seem to support ```padStart```, I patched by prepending the string with "0" and then ```substr(-2)``` to make sure we always have 2 chars representing the current byte in hex.