### PR TITLE
add installation instructions for jarsigner (java)

### DIFF
--- a/objection/utils/patchers/android.py
+++ b/objection/utils/patchers/android.py
@@ -188,7 +188,7 @@ class AndroidPatcher(BasePlatformPatcher):
             'installation': 'apt install adb (Kali Linux); brew install adb (macOS)'
         },
         'jarsigner': {
-            'installation': '#TODO'
+            'installation': 'apt install default-jre (Linux); brew cask install java (macOS)'
         },
         'apktool': {
             'installation': 'apt install apktool (Kali Linux)'


### PR DESCRIPTION
I think Kali comes with java (and therefore jarsigner) installed by default.