### PR TITLE
Improved patchapk experience

### DIFF
--- a/objection/console/cli.py
+++ b/objection/console/cli.py
@@ -336,9 +336,9 @@ def patchapk(source: str, architecture: str, gadget_version: str, pause: bool, s
         Patch an APK with the frida-gadget.so.
     """
 
-    # ensure we have the decode-resources flag if we have the network-security-config flag.
+    # ensure we decode resources if we have the network-security-config flag.
     if network_security_config and skip_resources:
-        click.secho('The --network-security-config flag requires the --decode-resources flag as well.', fg='red')
+        click.secho('The --network-security-config flag is incompatible with the --skip-resources flag.', fg='red')
         return
 
     patch_android_apk(**locals())

--- a/objection/console/cli.py
+++ b/objection/console/cli.py
@@ -341,6 +341,11 @@ def patchapk(source: str, architecture: str, gadget_version: str, pause: bool, s
         click.secho('The --network-security-config flag is incompatible with the --skip-resources flag.', fg='red')
         return
 
+    # ensure we decode resources if we have the enable-debug flag.
+    if enable_debug and skip_resources:
+        click.secho('The --enable-debug flag is incompatible with the --skip-resources flag.', fg='red')
+        return
+
     patch_android_apk(**locals())
 
 


### PR DESCRIPTION
This PR contains two patches that improve the overall `patchapk` experience.

First of all, 5b56e0f flipped the default resource decoding behavior but left a comment and an error message intact, which might lead to confusion, so I corrected it to match the rest of the code.

More importantly, I added a check so that the debug flag could only be flipped if resources are to be decoded. If not, Android binary XML is left as-is, thus when `_get_android_manifest` tries to parse it with the Python built-in `ElementTree` parser, your average Android reverse engineer is greeted with the following message:

```
$ objection patchapk -s victim.apk -d -D
No architecture specified. Determining it using `adb`...
Detected target device architecture as: arm64-v8a
Using latest Github gadget version: 12.7.11
Patcher will be using Gadget version: 12.7.11
Unpacking victim.apk
App already has android.permission.INTERNET
Traceback (most recent call last):
  File "/home/dnet/.local/bin/objection", line 10, in <module>
    sys.exit(cli())
  File "/home/dnet/.local/lib/python3.7/site-packages/click/core.py", line 764, in __call__
    return self.main(*args, **kwargs)
  File "/home/dnet/.local/lib/python3.7/site-packages/click/core.py", line 717, in main
    rv = self.invoke(ctx)
  File "/home/dnet/.local/lib/python3.7/site-packages/click/core.py", line 1137, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/dnet/.local/lib/python3.7/site-packages/click/core.py", line 956, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/dnet/.local/lib/python3.7/site-packages/click/core.py", line 555, in invoke
    return callback(*args, **kwargs)
  File "/home/dnet/.local/lib/python3.7/site-packages/objection/console/cli.py", line 344, in patchapk
    patch_android_apk(**locals())
  File "/home/dnet/.local/lib/python3.7/site-packages/objection/commands/mobile_packages.py", line 168, in patch_android_apk
    patcher.flip_debug_flag_to_true()
  File "/home/dnet/.local/lib/python3.7/site-packages/objection/utils/patchers/android.py", line 413, in flip_debug_flag_to_true
    xml = self._get_android_manifest()
  File "/home/dnet/.local/lib/python3.7/site-packages/objection/utils/patchers/android.py", line 240, in _get_android_manifest
    return ElementTree.parse(os.path.join(self.apk_temp_directory, 'AndroidManifest.xml'))
  File "/usr/lib/python3.7/xml/etree/ElementTree.py", line 1197, in parse
    tree.parse(source, parser)
  File "/usr/lib/python3.7/xml/etree/ElementTree.py", line 598, in parse
    self._root = parser._parse_whole(source)
xml.etree.ElementTree.ParseError: not well-formed (invalid token): line 1, column 0
Cleaning up temp files...
Failed to cleanup with error: [Errno 2] No such file or directory: '/tmp/tmpesy509ma.apktemp.objection.apk'
```

Confusing, isn't it? Of course, removing either `-d` or `-D` solved the issue, but the second patch makes it a bit easier to understand what the problem is and how to resolve it:

```
$ objection patchapk -s victim.apk -d -D
The --enable-debug flag is incompatible with the --skip-resources flag.
```