### PR TITLE
build_new_apk: carry extra files from META-INF over

### DIFF
--- a/objection/utils/patchers/android.py
+++ b/objection/utils/patchers/android.py
@@ -1,9 +1,12 @@
+import itertools
 import lzma
 import os
+import re
 import shlex
 import shutil
 import tempfile
 import xml.etree.ElementTree as ElementTree
+import zipfile
 from subprocess import list2cmdline
 
 import click
@@ -774,6 +777,26 @@ class AndroidPatcher(BasePlatformPatcher):
             click.secho(('Rebuilding the APK may have failed. Read the following '
                          'output to determine if apktool actually had an error: \n'), fg='red')
             click.secho(o.err, fg='red')
+
+        meta_inf = os.path.join(self.apk_temp_directory, 'original', 'META-INF')
+        standard_files = re.compile(r'^(?:[A-Z]+\.(?:RSA|SF)|MANIFEST\.MF)$')
+        extra_names = list(itertools.filterfalse(standard_files.match, os.listdir(meta_inf)))
+        if extra_names:
+            click.secho('Appending {0} extra entries in META-INF to the APK...'.format(len(extra_names)))
+            with zipfile.ZipFile(self.apk_temp_frida_patched, 'a', zipfile.ZIP_DEFLATED) as apk:
+                for extra_name in extra_names:
+                    full_path = os.path.join(meta_inf, extra_name)
+                    if os.path.isdir(full_path):
+                        prefix_len = len(full_path) + 1 # trailing '/'
+                        for dirpath, _, filenames in os.walk(full_path):
+                            for filename in filenames:
+                                src_name = os.path.join(dirpath, filename)
+                                dest_name = 'META-INF/{dirname}/{path}'.format(
+                                        dirname=extra_name,
+                                        path=src_name[prefix_len:].replace(os.sep, '/'))
+                                apk.write(src_name, dest_name)
+                    else:
+                        apk.write(full_path, 'META-INF/' + extra_name)
 
         click.secho('Built new APK with injected loadLibrary and frida-gadget', fg='green')
 

--- a/objection/utils/patchers/android.py
+++ b/objection/utils/patchers/android.py
@@ -778,6 +778,10 @@ class AndroidPatcher(BasePlatformPatcher):
                          'output to determine if apktool actually had an error: \n'), fg='red')
             click.secho(o.err, fg='red')
 
+        self._copy_meta_inf()
+        click.secho('Built new APK with injected loadLibrary and frida-gadget', fg='green')
+
+    def _copy_meta_inf(self):
         meta_inf = os.path.join(self.apk_temp_directory, 'original', 'META-INF')
         standard_files = re.compile(r'^(?:[A-Z]+\.(?:RSA|SF)|MANIFEST\.MF)$')
         extra_names = list(itertools.filterfalse(standard_files.match, os.listdir(meta_inf)))
@@ -797,8 +801,6 @@ class AndroidPatcher(BasePlatformPatcher):
                                 apk.write(src_name, dest_name)
                     else:
                         apk.write(full_path, 'META-INF/' + extra_name)
-
-        click.secho('Built new APK with injected loadLibrary and frida-gadget', fg='green')
 
     def zipalign_apk(self):
         """


### PR DESCRIPTION
Some features such as Kotlin coroutines use files stored in the `META-INF` directory. As described in [the Apktool documentation](https://ibotpeaches.github.io/Apktool/documentation/)

> **There is no META-INF dir in resulting apk. Is this ok?**
>
> Yes. `META-INF` contains apk signatures. After modifying the apk it is no longer signed. You can use `-c / --copy-original` to retain these signatures. However, using `-c` uses the original `AndroidManifest.xml` file, so changes to it will be lost. 

This results in `patchapk` producing APKs that crash as soon as Kotlin coroutines (or anything else that depend on files stored there) are used:

```
10-16 11:14:24.138  9824  9824 E AndroidRuntime: FATAL EXCEPTION: main
10-16 11:14:24.138  9824  9824 E AndroidRuntime: Process: com.example, PID: 9824
10-16 11:14:24.138  9824  9824 E AndroidRuntime: java.lang.IllegalStateException: Module with the Main dispatcher is missing. Add dependency providing the Main dispatcher, e.g. 'kotlinx-coroutines-android'
10-16 11:14:24.138  9824  9824 E AndroidRuntime:        at f.a.b.p.n(SourceFile:4)
10-16 11:14:24.138  9824  9824 E AndroidRuntime:        at f.a.b.p.b(SourceFile:1)
10-16 11:14:24.138  9824  9824 E AndroidRuntime:        at f.a.Z.a(SourceFile:11)
10-16 11:14:24.138  9824  9824 E AndroidRuntime:        at f.a.c.a.a(SourceFile:3)
10-16 11:14:24.138  9824  9824 E AndroidRuntime:        at kotlinx.coroutines.CoroutineStart.invoke(SourceFile:10)
```

This patch examines whether the `META-INF` directory contains anything else except the standard files used for `jarsigner` type (old) APK signatures (`*.RSA`, `*.SF` and `MANIFEST.MF`). If so, it uses the built-in ZIP file support of the Python standard library to append such files. For ZIP paths, [`/` is used as a separator regardless of the password](https://stackoverflow.com/a/44387973/246098), while for everything else, I used `os.path.join` and `os.sep`.

**Edit:** clarified that `/` is only used for ZIP paths