### PR TITLE
patchapk: added option to make use of aapt2

### DIFF
--- a/objection/commands/mobile_packages.py
+++ b/objection/commands/mobile_packages.py
@@ -87,7 +87,8 @@ def patch_ios_ipa(source: str, codesign_signature: str, provision_file: str, bin
 
 def patch_android_apk(source: str, architecture: str, pause: bool, skip_cleanup: bool = True,
                       enable_debug: bool = True, gadget_version: str = None, skip_resources: bool = False,
-                      network_security_config: bool = False, target_class: str = None) -> None:
+                      network_security_config: bool = False, target_class: str = None,
+                      use_aapt2: bool = False) -> None:
     """
         Patches an Android APK by extracting, patching SMALI, repackaging
         and signing a new APK.
@@ -101,6 +102,7 @@ def patch_android_apk(source: str, architecture: str, pause: bool, skip_cleanup:
         :param skip_resources:
         :param network_security_config:
         :param target_class:
+        :param use_aapt2:
 
         :return:
     """
@@ -182,7 +184,7 @@ def patch_android_apk(source: str, architecture: str, pause: bool, skip_cleanup:
 
         input('Press ENTER to continue...')
 
-    patcher.build_new_apk()
+    patcher.build_new_apk(use_aapt2=use_aapt2)
     patcher.sign_apk()
     patcher.zipalign_apk()
 

--- a/objection/console/cli.py
+++ b/objection/console/cli.py
@@ -330,8 +330,11 @@ def patchipa(source: str, gadget_version: str, codesign_signature: str, provisio
 @click.option('--skip-resources', '-D', is_flag=True, default=False,
               help='Skip resource decoding as part of the apktool processing.', show_default=False)
 @click.option('--target-class', '-t', help='The target class to patch.', default=None)
+@click.option('--use-aapt2', '-2', is_flag=True, default=False,
+              help='Use the aapt2 binary instead of aapt as part of the apktool processing.', show_default=False)
 def patchapk(source: str, architecture: str, gadget_version: str, pause: bool, skip_cleanup: bool,
-             enable_debug: bool, skip_resources: bool, network_security_config: bool, target_class: str) -> None:
+             enable_debug: bool, skip_resources: bool, network_security_config: bool, target_class: str,
+             use_aapt2: bool) -> None:
     """
         Patch an APK with the frida-gadget.so.
     """

--- a/objection/utils/patchers/android.py
+++ b/objection/utils/patchers/android.py
@@ -754,7 +754,7 @@ class AndroidPatcher(BasePlatformPatcher):
         click.secho('Copying Frida gadget to libs path...', fg='green', dim=True)
         shutil.copyfile(gadget_source, os.path.join(libs_path, 'libfrida-gadget.so'))
 
-    def build_new_apk(self):
+    def build_new_apk(self, use_aapt2: bool = False):
         """
             Build a new .apk with the frida-gadget patched in.
 
@@ -766,6 +766,7 @@ class AndroidPatcher(BasePlatformPatcher):
             self.required_commands['apktool']['location'],
             'build',
             self.apk_temp_directory,
+        ] + (['--use-aapt2'] if use_aapt2 else []) + [
             '-o',
             self.apk_temp_frida_patched
         ]), timeout=self.command_run_timeout)


### PR DESCRIPTION
As mentioned in sensepost/objection#253

> Apktool uses aapt1 by default when recompiling. But some apps require aapt2 and for that reason apktool has the flag `--use-aapt2` but _objection_ has no such flags, hence it throws exception during recompilation.

This patch adds an option to pass the appropriate flag to `apktool` while retaining the current behavior as default.