### PR TITLE
Fix android hook overload filter.

### DIFF
--- a/objection/commands/android/hooking.py
+++ b/objection/commands/android/hooking.py
@@ -132,11 +132,11 @@ def watch_class_method(args: list) -> None:
         return
 
     fully_qualified_class = args[0]
-    overload_filter = args[1] if '--' not in args[1] else None
+    overload_filter = args[1].replace(' ', '') if '--' not in args[1] else None
 
     api = state_connection.get_api()
     api.android_hooking_watch_method(fully_qualified_class,
-                                     overload_filter.replace(' ', ''),
+                                     overload_filter,
                                      _should_dump_args(args),
                                      _should_dump_backtrace(args),
                                      _should_dump_return_value(args))


### PR DESCRIPTION
```
android hooking watch class_method android.util.Base64.decode --dump-args


An unexpected internal exception has occurred. If this looks like a code related error, please file a bug report!
'NoneType' object has no attribute 'replace'

Python stack trace: Traceback (most recent call last):
  File "/usr/local/lib/python3.7/site-packages/objection/console/repl.py", line 371, in start_repl
    self.run_command(document)
  File "/usr/local/lib/python3.7/site-packages/objection/console/repl.py", line 185, in run_command
    exec_method(arguments)
  File "/usr/local/lib/python3.7/site-packages/objection/commands/android/hooking.py", line 139, in watch_class_method
    overload_filter.replace(' ', ''),
AttributeError: 'NoneType' object has no attribute 'replace'
```