### PR TITLE
_copy_meta_inf: accept all legal base file names

### DIFF
--- a/objection/utils/patchers/android.py
+++ b/objection/utils/patchers/android.py
@@ -784,7 +784,7 @@ class AndroidPatcher(BasePlatformPatcher):
 
     def _copy_meta_inf(self):
         meta_inf = os.path.join(self.apk_temp_directory, 'original', 'META-INF')
-        standard_files = re.compile(r'^(?:[A-Z]+\.(?:RSA|SF)|MANIFEST\.MF)$')
+        standard_files = re.compile(r'^(?:[A-Z0-9_-]+\.(?:RSA|SF)|MANIFEST\.MF)$')
         extra_names = list(itertools.filterfalse(standard_files.match, os.listdir(meta_inf)))
         if extra_names:
             click.secho('Appending {0} extra entries in META-INF to the APK...'.format(len(extra_names)))


### PR DESCRIPTION
As the documentation states:

> If the alias name contains any characters that are not allowed in a signature file name, each such character is converted to an underscore ("_") character in forming the file name. Legal characters include letters, digits, underscores, and hyphens.

This commit adds the missing part to the regex: digits, underscore and hyphen, so that all key names are covered, otherwise there could be multiple signature files, resulting in confused verifiers.