### PR TITLE
ios ssl pinning: add support for iOS 13

### DIFF
--- a/agent/src/ios/lib/libobjc.ts
+++ b/agent/src/ios/lib/libobjc.ts
@@ -72,6 +72,14 @@ const nativeExports: any = {
     moduleName: "libboringssl.dylib",
     retType: "pointer",
   },
+
+  // iOS 13+ libboringssl methods
+  SSL_set_custom_verify: {
+    argTypes: ["pointer", "int", "pointer"],
+    exportName: "SSL_set_custom_verify",
+    moduleName: "libboringssl.dylib",
+    retType: "void",
+  },
 };
 
 const api: any = {
@@ -89,6 +97,8 @@ const api: any = {
 
   SSL_CTX_set_custom_verify: null,
   SSL_get_psk_identity: null,
+
+  SSL_set_custom_verify: null,
 };
 
 // proxy method resolution
@@ -97,8 +107,9 @@ export const libObjc = new Proxy(api, {
 
     if (target[key] === null) {
 
-      target[key] = new NativeFunction(Module.findExportByName(
-        nativeExports[key].moduleName, nativeExports[key].exportName),
+      const f = Module.findExportByName(
+        nativeExports[key].moduleName, nativeExports[key].exportName) || ptr('0');
+      target[key] = new NativeFunction(f,
         nativeExports[key].retType, nativeExports[key].argTypes);
     }
 

--- a/agent/src/ios/pinning.ts
+++ b/agent/src/ios/pinning.ts
@@ -447,8 +447,11 @@ export namespace sslpinning {
 
   // SSL_CTX_set_custom_verify
   const sSLCtxSetCustomVerify = (ident: string): InvocationListener => {
-    const setCustomVerify = libObjc.SSL_CTX_set_custom_verify;
     const getPskIdentity = libObjc.SSL_get_psk_identity;
+    var setCustomVerify = libObjc.SSL_CTX_set_custom_verify;
+    if (setCustomVerify.isNull()) {
+        setCustomVerify = libObjc.SSL_set_custom_verify;
+    }
 
     if (setCustomVerify.isNull() || getPskIdentity.isNull()) {
       return null;

--- a/agent/src/ios/pinning.ts
+++ b/agent/src/ios/pinning.ts
@@ -448,9 +448,9 @@ export namespace sslpinning {
   // SSL_CTX_set_custom_verify
   const sSLCtxSetCustomVerify = (ident: string): InvocationListener => {
     const getPskIdentity = libObjc.SSL_get_psk_identity;
-    var setCustomVerify = libObjc.SSL_CTX_set_custom_verify;
+    var setCustomVerify = libObjc.SSL_set_custom_verify;
     if (setCustomVerify.isNull()) {
-        setCustomVerify = libObjc.SSL_set_custom_verify;
+        setCustomVerify = libObjc.SSL_CTX_set_custom_verify;
     }
 
     if (setCustomVerify.isNull() || getPskIdentity.isNull()) {


### PR DESCRIPTION
based on https://github.com/nabla-c0d3/ssl-kill-switch2/pull/72

cc #281