### PR TITLE
Fix android hooking set return_value crashing if optional overload is NA

### DIFF
--- a/objection/commands/android/hooking.py
+++ b/objection/commands/android/hooking.py
@@ -233,12 +233,12 @@ def set_method_return_value(args: list = None) -> None:
     class_name = args[0].replace('\'', '"')  # fun!
 
     # check if we got an overload
-    overload_filter = args[1] if len(args) == 3 else None
+    overload_filter = args[1].replace(' ', '') if len(args) == 3 else None
     retval = True if _string_is_true(args[-1]) else False
 
     api = state_connection.get_api()
     api.android_hooking_set_method_return(class_name,
-                                          overload_filter.replace(' ', ''),
+                                          overload_filter,
                                           retval)
 
 


### PR DESCRIPTION

crashes on:
 android hooking set return_value appuri.myMethod true

Error:
An unexpected internal exception has occurred. If this looks like a code related error, please file a bug report!
'NoneType' object has no attribute 'replace'

Python stack trace: Traceback (most recent call last):
  File "/home/xxx/objection/objection/console/repl.py", line 371, in start_repl
    self.run_command(document)
  File "/home/xxx/objection/objection/console/repl.py", line 185, in run_command
    exec_method(arguments)
  File "/home/xxx/objection/objection/commands/android/hooking.py", line 242, in set_method_return_value
    overload_filter.replace(' ', ''),
AttributeError: 'NoneType' object has no attribute 'replace'