### PR TITLE
added unicode support during the IPA extraction

### DIFF
--- a/objection/commands/mobile_packages.py
+++ b/objection/commands/mobile_packages.py
@@ -11,7 +11,7 @@ from ..utils.patchers.ios import IosGadget, IosPatcher
 
 
 def patch_ios_ipa(source: str, codesign_signature: str, provision_file: str, binary_name: str,
-                  skip_cleanup: bool, gadget_version: str = None, pause: bool = False) -> None:
+                  skip_cleanup: bool, unzip_unicode: bool, gadget_version: str = None, pause: bool = False) -> None:
     """
         Patches an iOS IPA by extracting, injecting the Frida dylib,
         codesigning the dylib and app executable and rezipping the IPA.
@@ -21,6 +21,7 @@ def patch_ios_ipa(source: str, codesign_signature: str, provision_file: str, bin
         :param provision_file:
         :param binary_name:
         :param skip_cleanup:
+        :param unzip_unicode:
         :param gadget_version:
         :return:
     """

--- a/objection/console/cli.py
+++ b/objection/console/cli.py
@@ -300,8 +300,9 @@ def device_type():
               help='Do not clean temporary files once finished.', show_default=True)
 @click.option('--pause', '-p', is_flag=True, help='Pause the patcher before rebuilding the IPA.',
               show_default=True)
+@click.option('--unzip-unicode', '-z',  is_flag=True, help='Unzip IPA containing Unicode characters.')
 def patchipa(source: str, gadget_version: str, codesign_signature: str, provision_file: str, binary_name: str,
-             skip_cleanup: bool, pause: bool) -> None:
+             skip_cleanup: bool, pause: bool, unzip_unicode: bool) -> None:
     """
         Patch an IPA with the FridaGadget dylib.
     """

--- a/objection/utils/patchers/ios.py
+++ b/objection/utils/patchers/ios.py
@@ -267,9 +267,15 @@ class IosPatcher(BasePlatformPatcher):
         shutil.copyfile(ipa_source, self.temp_file)
 
         # extract the IPA this should result in a 'Payload' directory
-        ipa = zipfile.ZipFile(self.temp_file, 'r')
-        ipa.extractall(self.temp_directory)
-        ipa.close()
+        #ipa = zipfile.ZipFile(self.temp_file, 'r')
+        #ipa.extractall(self.temp_directory)
+        #ipa.close()
+
+        # this works for IPA which contains unicode characters
+        with zipfile.ZipFile(self.temp_file, 'r') as ipa:
+            for info in ipa.infolist():
+                info.filename = info.filename.encode('cp437').decode('utf-8')
+                ipa.extract(info,self.temp_directory)
 
         # check what is in the Payload directory
         self.payload_directory = os.listdir(os.path.join(self.temp_directory, 'Payload'))

--- a/objection/utils/patchers/ios.py
+++ b/objection/utils/patchers/ios.py
@@ -265,17 +265,17 @@ class IosPatcher(BasePlatformPatcher):
 
         # copy the orignal ipa to the temp directory.
         shutil.copyfile(ipa_source, self.temp_file)
-
-        # extract the IPA this should result in a 'Payload' directory
-        #ipa = zipfile.ZipFile(self.temp_file, 'r')
-        #ipa.extractall(self.temp_directory)
-        #ipa.close()
-
+        if (unzip_unicode):
+            print('\n\nCIAOOOOOOOO\n\n')
         # this works for IPA which contains unicode characters
-        with zipfile.ZipFile(self.temp_file, 'r') as ipa:
-            for info in ipa.infolist():
-                info.filename = info.filename.encode('cp437').decode('utf-8')
-                ipa.extract(info,self.temp_directory)
+        #with zipfile.ZipFile(self.temp_file, 'r') as ipa:
+        #    for info in ipa.infolist():
+        #        info.filename = info.filename.encode('cp437').decode('utf-8')
+        #        ipa.extract(info,self.temp_directory)
+        # extract the IPA this should result in a 'Payload' directory
+        ipa = zipfile.ZipFile(self.temp_file, 'r')
+        ipa.extractall(self.temp_directory)
+        ipa.close()
 
         # check what is in the Payload directory
         self.payload_directory = os.listdir(os.path.join(self.temp_directory, 'Payload'))


### PR DESCRIPTION
Dear All, I'm a security anlyst of QuantumLeap-Deloitte and during an activity I had some problems extracting a IPA file containing Chinese characters, so  I thought to add a support for the unicode encoding.