### PR TITLE
Add gadget config and script to apk patcher

### DIFF
--- a/objection/commands/mobile_packages.py
+++ b/objection/commands/mobile_packages.py
@@ -88,7 +88,7 @@ def patch_ios_ipa(source: str, codesign_signature: str, provision_file: str, bin
 def patch_android_apk(source: str, architecture: str, pause: bool, skip_cleanup: bool = True,
                       enable_debug: bool = True, gadget_version: str = None, skip_resources: bool = False,
                       network_security_config: bool = False, target_class: str = None,
-                      use_aapt2: bool = False) -> None:
+                      use_aapt2: bool = False, gadget_config: str = None, script_source: str = None) -> None:
     """
         Patches an Android APK by extracting, patching SMALI, repackaging
         and signing a new APK.
@@ -103,6 +103,8 @@ def patch_android_apk(source: str, architecture: str, pause: bool, skip_cleanup:
         :param network_security_config:
         :param target_class:
         :param use_aapt2:
+        :param gadget_config:
+        :param script_source:
 
         :return:
     """
@@ -173,7 +175,10 @@ def patch_android_apk(source: str, architecture: str, pause: bool, skip_cleanup:
         patcher.add_network_security_config()
 
     patcher.inject_load_library(target_class=target_class)
-    patcher.add_gadget_to_apk(architecture, android_gadget.get_frida_library_path())
+    patcher.add_gadget_to_apk(architecture, android_gadget.get_frida_library_path(), gadget_config)
+
+    if script_source:
+        shutil.copyfile(script_source, os.path.join(patcher.apk_temp_directory, 'lib', architecture, 'libfrida-gadget.script.so'))
 
     # if we are required to pause, do that.
     if pause:

--- a/objection/console/cli.py
+++ b/objection/console/cli.py
@@ -332,9 +332,12 @@ def patchipa(source: str, gadget_version: str, codesign_signature: str, provisio
 @click.option('--target-class', '-t', help='The target class to patch.', default=None)
 @click.option('--use-aapt2', '-2', is_flag=True, default=False,
               help='Use the aapt2 binary instead of aapt as part of the apktool processing.', show_default=False)
+@click.option('--gadget-config', '-c', default=None, help='The gadget configuration to use.', show_default=False)
+@click.option('--script-source', '-l', default=None,
+              help='A script file which will be copied to libfrida-gadget.script.so', show_default=False)
 def patchapk(source: str, architecture: str, gadget_version: str, pause: bool, skip_cleanup: bool,
              enable_debug: bool, skip_resources: bool, network_security_config: bool, target_class: str,
-             use_aapt2: bool) -> None:
+             use_aapt2: bool, gadget_config: str, script_source: str) -> None:
     """
         Patch an APK with the frida-gadget.so.
     """

--- a/objection/utils/patchers/android.py
+++ b/objection/utils/patchers/android.py
@@ -737,13 +737,14 @@ class AndroidPatcher(BasePlatformPatcher):
         with open(activity_path, 'w') as f:
             f.write(''.join(patched_smali))
 
-    def add_gadget_to_apk(self, architecture: str, gadget_source: str):
+    def add_gadget_to_apk(self, architecture: str, gadget_source: str, gadget_config: str):
         """
             Copies a frida gadget for a specific architecture to
             an extracted APK's lib path.
 
             :param architecture:
             :param gadget_source:
+            :param gadget_config:
             :return:
         """
 
@@ -756,6 +757,8 @@ class AndroidPatcher(BasePlatformPatcher):
 
         click.secho('Copying Frida gadget to libs path...', fg='green', dim=True)
         shutil.copyfile(gadget_source, os.path.join(libs_path, 'libfrida-gadget.so'))
+        if gadget_config:
+            shutil.copyfile(gadget_config, os.path.join(libs_path, 'libfrida-gadget.config.so'))
 
     def build_new_apk(self, use_aapt2: bool = False):
         """


### PR DESCRIPTION
This adds two options to the apk patcher:
1. Allow specifying a file to be used as gadget config
2. Allow adding a script to be pushed into /data/app/com.example/lib/arch/libfrida-gadget.script.so

These can be used together to allow configring the gadget to load an included script instead of listening for connections, which could be useful for patching applications permanently without writing smali.