### PR TITLE
Set error=null on biometric bypass

### DIFF
--- a/agent/src/ios/userinterface.ts
+++ b/agent/src/ios/userinterface.ts
@@ -114,6 +114,7 @@ export namespace userinterface {
 
               // Change the success response from the OS to true
               success = true;
+              error = null;
             }
 
             // and run the original block


### PR DESCRIPTION
When performing the biometric authentication bypass we should also set the `error` to `null` as some app do not check the success and instead check if there is an error.


e.g. 

```
context.evaluatePolicy(
    .deviceOwnerAuthenticationWithBiometrics,
    localizedReason:prompt,
    reply: { _, error in
        DispatchQueue.main.async {
            if let error = error {
                self.handleFailure(error)
            } else {
               self.handleSuccess()
            }
        }
    }
)
```