### PR TITLE
Android watch methods print args and return detail

### DIFF
--- a/agent/src/android/hooking.ts
+++ b/agent/src/android/hooking.ts
@@ -159,7 +159,7 @@ export namespace hooking {
           if (dargs && calleeArgTypes.length > 0) {
             const argValues: string[] = [];
             for (const h of arguments) {
-              argValues.push((h || "(none)").toString());
+              argValues.push(JSON.stringify(h || "(none)"));
             }
 
             send(
@@ -173,7 +173,7 @@ export namespace hooking {
 
           // dump the return value
           if (dret) {
-            const retValStr: string = (retVal || "(none)").toString();
+            const retValStr: string = JSON.stringify(retVal || "(none)");
             send(c.blackBright(`[${job.identifier}] `) + `Return Value: ${c.red(retValStr)}`);
           }
 


### PR DESCRIPTION
This PR related to #325 
When performing the `watch method` in Android, objection only print `[object, object]` for Object and Array. This is happening both for args and return.
e.g:
`Arguments com.foo.example.Main.method(Hello World, [object Object], [object Object])                                      
`