### PR TITLE
Add gadget config and script to IPA patcher

### DIFF
--- a/objection/console/cli.py
+++ b/objection/console/cli.py
@@ -301,8 +301,13 @@ def device_type():
 @click.option('--pause', '-p', is_flag=True, help='Pause the patcher before rebuilding the IPA.',
               show_default=True)
 @click.option('--unzip-unicode', '-z', is_flag=True, help='Unzip IPA containing Unicode characters.')
+@click.option('--gadget-config', '-C', default=None, help=(
+        'The gadget configuration file to use. '
+        'Refer to https://frida.re/docs/gadget/ for more information.'), show_default=False)
+@click.option('--script-source', '-l', default=None, help=(
+        'A script file to use with the the "path" config type.'), show_default=False)
 def patchipa(source: str, gadget_version: str, codesign_signature: str, provision_file: str, binary_name: str,
-             skip_cleanup: bool, pause: bool, unzip_unicode: bool) -> None:
+             skip_cleanup: bool, pause: bool, unzip_unicode: bool, gadget_config: str, script_source: str) -> None:
     """
         Patch an IPA with the FridaGadget dylib.
     """

--- a/objection/utils/patchers/ios.py
+++ b/objection/utils/patchers/ios.py
@@ -316,7 +316,7 @@ class IosPatcher(BasePlatformPatcher):
 
         self.app_binary = os.path.join(self.app_folder, info_plist['CFBundleExecutable'])
 
-    def patch_and_codesign_binary(self, frida_gadget: str, codesign_signature: str) -> None:
+    def patch_and_codesign_binary(self, frida_gadget: str, codesign_signature: str, gadget_config: str) -> None:
         """
             Patches an iOS binary to load a Frida gadget on startup.
 
@@ -325,6 +325,7 @@ class IosPatcher(BasePlatformPatcher):
 
             :param frida_gadget:
             :param codesign_signature:
+            :param gadget_config:
             :return:
         """
 
@@ -341,6 +342,9 @@ class IosPatcher(BasePlatformPatcher):
 
         # copy the frida gadget to the applications Frameworks directory
         shutil.copyfile(frida_gadget, os.path.join(self.app_folder, 'Frameworks', 'FridaGadget.dylib'))
+        if gadget_config:
+            click.secho('Copying Gadget Config to Frameworks path...', fg='green', dim=True)
+            shutil.copyfile(gadget_config, os.path.join(self.app_folder, 'Frameworks', 'FridaGadget.config'))
 
         # patch the app binary
         load_library_output = delegator.run(list2cmdline(


### PR DESCRIPTION
This adds two options to the IPA patcher:
1. Allow specifying a file to be used as gadget config
2. Allow adding a script to be pushed into ```Payload/AppName.app/Frameworks/ScriptName.js```

These can be used together to allow configuring the gadget to load an included script instead of listening for connections, which could be useful for patching applications permanently.

PR changes test output below and ran DVIA iOS app with successful inclusion of ```FridaGadget.config``` and ```script.js``` files inside ```Frameworks``` directory
```
(virtual-objection-dev) tester@testers-Mac dev % objection patchipa -C FridaGadget.config -l script.js -s DamnVulnerableiOSApp.ipa --codesign-signature XXXXXXXXXX
Using latest Github gadget version: 12.8.19
Patcher will be using Gadget version: 12.8.19
No provision file specified, searching for one...
Found provision file /Users/tester/Library/Developer/Xcode/DerivedData/testerapp20200328-ftktaifvfjfcurafabocdwtpmiic/Build/Products/Debug-iphoneos/testerapp20200328.app/embedded.mobileprovision expiring in 5 days, 5:24:22.161002
Found a valid provisioning profile
Working with app: DamnVulnerableIOSApp.app
Bundle identifier is: com.highaltitudehacks.dvia
Creating Frameworks directory for FridaGadget...
Copying Gadget Config to Frameworks path...
Codesigning 1 .dylib's with signature XXXXXXXXXX
Code signing: FridaGadget.dylib
Copying over a custom script to use with the gadget config.
Creating new archive with patched contents...
Codesigning patched IPA...
Cannot find entitlements in binary. Using defaults

Copying final ipa from /var/folders/f4/4rycq9cs7pdf542yh_659m1m0000gn/T/DamnVulnerableiOSApp-frida-codesigned.ipa to current directory...
Cleaning up temp files...
```

Thanks to @gergesh for the APK Patcher PR from which this PR has been generated for IPA Patcher.
Thanks to @securitytest3r repository (https://github.com/securitytest3r/frida-ios-app-patching) for testing the PR changes.