### PR TITLE
Fix incorrect argument list quoting in POSIX systems

### DIFF
--- a/objection/utils/patchers/android.py
+++ b/objection/utils/patchers/android.py
@@ -1,10 +1,8 @@
 import lzma
 import os
-import shlex
 import shutil
 import tempfile
 import xml.etree.ElementTree as ElementTree
-from subprocess import list2cmdline
 from pkg_resources import parse_version
 
 import click
@@ -222,7 +220,7 @@ class AndroidPatcher(BasePlatformPatcher):
 
         min_version = '2.4.1'  # the version of apktool we require
 
-        o = delegator.run(list2cmdline([
+        o = delegator.run(self.list2cmdline([
             self.required_commands['apktool']['location'],
             '-version',
         ]), timeout=self.command_run_timeout).out.strip()
@@ -246,7 +244,7 @@ class AndroidPatcher(BasePlatformPatcher):
 
         # run clean-frameworks-dir
         click.secho('Running apktool empty-framework-dir...', dim=True)
-        o = delegator.run(list2cmdline([
+        o = delegator.run(self.list2cmdline([
             self.required_commands['apktool']['location'],
             'empty-framework-dir',
         ]), timeout=self.command_run_timeout).out.strip()
@@ -267,7 +265,7 @@ class AndroidPatcher(BasePlatformPatcher):
         if not os.path.exists(source):
             raise Exception('Source {0} not found.'.format(source))
 
-        self.apk_source = shlex.quote(source)
+        self.apk_source = source
 
         return self
 
@@ -291,7 +289,7 @@ class AndroidPatcher(BasePlatformPatcher):
         """
 
         if not self.aapt:
-            o = delegator.run(list2cmdline([
+            o = delegator.run(self.list2cmdline([
                 self.required_commands['aapt']['location'],
                 'dump',
                 'badging',
@@ -394,7 +392,7 @@ class AndroidPatcher(BasePlatformPatcher):
 
         click.secho('Unpacking {0}'.format(self.apk_source), dim=True)
 
-        o = delegator.run(list2cmdline([
+        o = delegator.run(self.list2cmdline([
             self.required_commands['apktool']['location'],
             'decode',
             '-f',
@@ -845,7 +843,7 @@ class AndroidPatcher(BasePlatformPatcher):
 
         click.secho('Rebuilding the APK with the frida-gadget loaded...', fg='green', dim=True)
         o = delegator.run(
-            list2cmdline([self.required_commands['apktool']['location'],
+            self.list2cmdline([self.required_commands['apktool']['location'],
                           'build',
                           self.apk_temp_directory,
                           ] + (['--use-aapt2'] if use_aapt2 else []) + [
@@ -869,7 +867,7 @@ class AndroidPatcher(BasePlatformPatcher):
 
         click.secho('Performing zipalign', dim=True)
 
-        o = delegator.run(list2cmdline([
+        o = delegator.run(self.list2cmdline([
             self.required_commands['zipalign']['location'],
             '-p',
             '4',
@@ -897,7 +895,7 @@ class AndroidPatcher(BasePlatformPatcher):
 
         click.secho('Signing new APK.', dim=True)
 
-        o = delegator.run(list2cmdline([
+        o = delegator.run(self.list2cmdline([
             self.required_commands['jarsigner']['location'],
             '-sigalg',
             'SHA1withRSA',

--- a/objection/utils/patchers/base.py
+++ b/objection/utils/patchers/base.py
@@ -3,12 +3,25 @@ import os
 import shutil
 
 import click
+import shlex
+from subprocess import list2cmdline
 
 from .github import Github
 
 # default paths
 objection_path = os.path.join(os.path.expanduser('~'), '.objection')
 gadget_versions = os.path.join(objection_path, 'gadget_versions')
+
+def list2posix_cmdline(seq):
+    """
+        Translate a sequence of arguments into a command line
+        string.
+
+        Implemented using shlex.quote because 
+        subprocess.list2cmdline doesn't work with POSIX
+    """
+        
+    return ' '.join(map(shlex.quote, seq))
 
 
 class BasePlatformGadget(object):
@@ -99,6 +112,11 @@ class BasePlatformPatcher(object):
         self.have_all_commands = self._check_commands()
         self.command_run_timeout = 60 * 5
 
+        if os.name == 'nt':
+            self.list2cmdline = list2cmdline
+        else:
+            self.list2cmdline = list2posix_cmdline
+    
     def _check_commands(self) -> bool:
         """
             Check if the shell commands in required_commands are

--- a/objection/utils/patchers/ios.py
+++ b/objection/utils/patchers/ios.py
@@ -5,7 +5,6 @@ import plistlib
 import shutil
 import tempfile
 import zipfile
-from subprocess import list2cmdline
 
 import click
 import delegator
@@ -220,7 +219,7 @@ class IosPatcher(BasePlatformPatcher):
             _, decoded_location = tempfile.mkstemp('decoded_provision')
 
             # Decode the mobile provision using macOS's security cms tool
-            delegator.run(list2cmdline(
+            delegator.run(self.list2cmdline(
                 [
                     self.required_commands['security']['location'],
                     'cms',
@@ -347,7 +346,7 @@ class IosPatcher(BasePlatformPatcher):
             shutil.copyfile(gadget_config, os.path.join(self.app_folder, 'Frameworks', 'FridaGadget.config'))
 
         # patch the app binary
-        load_library_output = delegator.run(list2cmdline(
+        load_library_output = delegator.run(self.list2cmdline(
             [
                 self.required_commands['insert_dylib']['location'],
                 '--strip-codesig',
@@ -375,7 +374,7 @@ class IosPatcher(BasePlatformPatcher):
                     fg='green')
         for dylib in dylibs_to_sign:
             click.secho('Code signing: {0}'.format(os.path.basename(dylib)), dim=True)
-            delegator.run(list2cmdline([
+            delegator.run(self.list2cmdline([
                 self.required_commands['codesign']['location'],
                 '-f',
                 '-v',
@@ -414,7 +413,7 @@ class IosPatcher(BasePlatformPatcher):
         self.patched_codesigned_ipa_path = os.path.join(self.temp_directory, os.path.basename(
             '{0}-frida-codesigned.ipa'.format(os.path.splitext(original_name)[0])))
 
-        ipa_codesign = delegator.run(list2cmdline(
+        ipa_codesign = delegator.run(self.list2cmdline(
             [
                 self.required_commands['applesign']['location'],
                 '-i',


### PR DESCRIPTION
Use only shlex for POSIX systems and only subprocess.list2cmdline for NT.
According to https://bugs.python.org/issue37659 shlex and list2cmdline are
not coherent with each other so using them in conjunction may lead to
quoting correct neigher in Unix nor in Windows.

One simple example is 'app 1.apk'. It will be quoted once by shlex
(`"'app 1.apk'"`) and another time by cmdline resulting in mad
`"\"'app 1.apk'\""`. Removing shlex won't help because of bug #234. At the same
time shlex won't work with NT (python bug 37659), so the only reasonable fix
is splitting them based on the OS.