### PR TITLE
Streamlining error handling when --skip-resources is set

### DIFF
--- a/objection/commands/mobile_packages.py
+++ b/objection/commands/mobile_packages.py
@@ -172,7 +172,7 @@ def patch_android_apk(source: str, architecture: str, pause: bool, skip_cleanup:
 
     click.secho('Patcher will be using Gadget version: {0}'.format(github_version), fg='green')
 
-    patcher = AndroidPatcher(skip_cleanup=skip_cleanup)
+    patcher = AndroidPatcher(skip_cleanup=skip_cleanup, skip_resources=skip_resources)
 
     # ensure we have the latest apk-tool and run the
     if not patcher.is_apktool_ready():
@@ -185,8 +185,8 @@ def patch_android_apk(source: str, architecture: str, pause: bool, skip_cleanup:
 
     # work on patching the APK
     patcher.set_apk_source(source=source)
-    patcher.unpack_apk(skip_resources=skip_resources)
-    patcher.inject_internet_permission(skip_resources=skip_resources)
+    patcher.unpack_apk()
+    patcher.inject_internet_permission()
 
     if not ignore_nativelibs:
         patcher.extract_native_libs_patch()

--- a/objection/console/cli.py
+++ b/objection/console/cli.py
@@ -363,6 +363,11 @@ def patchapk(source: str, architecture: str, gadget_version: str, pause: bool, s
         click.secho('The --enable-debug flag is incompatible with the --skip-resources flag.', fg='red')
         return
 
+    # ensure we decode resources if we do not have the --ignore-nativelibs flag.
+    if not ignore_nativelibs and skip_resources:
+        click.secho('The --ignore-nativelibs flag is required with the --skip-resources flag.', fg='red')
+        return
+
     patch_android_apk(**locals())
 
 

--- a/objection/utils/patchers/android.py
+++ b/objection/utils/patchers/android.py
@@ -197,7 +197,7 @@ class AndroidPatcher(BasePlatformPatcher):
         }
     }
 
-    def __init__(self, skip_cleanup: bool = False):
+    def __init__(self, skip_cleanup: bool = False, skip_resources: bool = False):
         super(AndroidPatcher, self).__init__()
 
         self.apk_source = None
@@ -206,6 +206,7 @@ class AndroidPatcher(BasePlatformPatcher):
         self.apk_temp_frida_patched_aligned = self.apk_temp_directory + '.aligned.objection.apk'
         self.aapt = None
         self.skip_cleanup = skip_cleanup
+        self.skip_resources = skip_resources
 
         self.keystore = os.path.join(os.path.abspath(os.path.dirname(__file__)), '../assets', 'objection.jks')
         self.netsec_config = os.path.join(os.path.abspath(os.path.dirname(__file__)), '../assets',
@@ -275,6 +276,12 @@ class AndroidPatcher(BasePlatformPatcher):
 
             :return:
         """
+
+        # error if --skip-resources was used because the manifest is encoded
+        if self.skip_resources is True:
+            click.secho('Cannot manually parse the AndroidManifest.xml when --skip-resources '
+                        'is set, remove this and try again.', fg='red')
+            raise Exception('Cannot --skip-resources when trying to manually parse the AndroidManifest.xml')
 
         # use the android namespace
         ElementTree.register_namespace('android', 'http://schemas.android.com/apk/res/android')
@@ -381,11 +388,9 @@ class AndroidPatcher(BasePlatformPatcher):
 
         return self.apk_temp_directory
 
-    def unpack_apk(self, skip_resources: bool = False):
+    def unpack_apk(self):
         """
             Unpack an APK with apktool.
-
-            :type skip_resources: bool
 
             :return:
         """
@@ -396,7 +401,7 @@ class AndroidPatcher(BasePlatformPatcher):
             self.required_commands['apktool']['location'],
             'decode',
             '-f',
-            '-r' if skip_resources else '',
+            '-r' if self.skip_resources else '',
             '-o',
             self.apk_temp_directory,
             self.apk_source
@@ -406,7 +411,7 @@ class AndroidPatcher(BasePlatformPatcher):
             click.secho('An error may have occurred while extracting the APK.', fg='red')
             click.secho(o.err, fg='red')
 
-    def inject_internet_permission(self, skip_resources: bool = False):
+    def inject_internet_permission(self):
         """
             Checks the status of the source APK to see if it
             has the INTERNET permission. If not, the manifest file
@@ -422,13 +427,8 @@ class AndroidPatcher(BasePlatformPatcher):
             click.secho('App already has android.permission.INTERNET', fg='green')
             return
 
-        # if not, error if --skip-resources was used because the manifest is encoded
-        elif skip_resources is True:
-            click.secho('Cannot patch an APK for Internet permission when --skip-resources '
-                        'is set, remove this and try again.', fg='red')
-            raise Exception('Cannot --skip-resources with no Internet permission')
-
         # if not, we need to inject an element with it
+        click.secho('App does not have android.permission.INTERNET, attempting to patch the AndroidManifest.xml...', dim=True, fg='yellow')
         xml = self._get_android_manifest()
         root = xml.getroot()
 


### PR DESCRIPTION
objection patchapk currently does not work well when --skip-resources is set. Especially since the addition of --ignore-nativelibs, objection patchapk does not work at all with --skip-resources unless --ignore-nativelibs is set.

In order to improve the situation somewhat, objection patchapk now handles a missing --ignore-nativelibs similar to a given --enable-debug and prints an incompatibility warning. Also, the check for skip_resources within AndroidPatcher has been moved into the _get_android_manifest function to avoid checks all over the place.
