### PR TITLE
Add 'objection signapk' command to facilitate split APK patching

### DIFF
--- a/objection/commands/mobile_packages.py
+++ b/objection/commands/mobile_packages.py
@@ -216,8 +216,35 @@ def patch_android_apk(source: str, architecture: str, pause: bool, skip_cleanup:
         input('Press ENTER to continue...')
 
     patcher.build_new_apk(use_aapt2=use_aapt2)
-    patcher.sign_apk()
     patcher.zipalign_apk()
+    patcher.sign_apk()
+
+    # woohoo, get the APK!
+    destination = source.replace('.apk', '.objection.apk')
+
+    click.secho(
+        'Copying final apk from {0} to {1} in current directory...'.format(patcher.get_patched_apk_path(), destination))
+    shutil.copyfile(patcher.get_patched_apk_path(), os.path.join(os.path.abspath('.'), destination))
+
+def sign_android_apk(source: str, skip_cleanup: bool = True) -> None:
+    """
+        Zipaligns and signs an Android APK with the objection key.
+
+        :param source:
+        :param skip_cleanup:
+
+        :return:
+    """
+
+    patcher = AndroidPatcher(skip_cleanup=skip_cleanup)
+
+    # ensure that we have all of the commandline requirements
+    if not patcher.are_requirements_met():
+        return
+
+    patcher.set_apk_source(source=source)
+    patcher.zipalign_apk()
+    patcher.sign_apk()
 
     # woohoo, get the APK!
     destination = source.replace('.apk', '.objection.apk')

--- a/objection/console/cli.py
+++ b/objection/console/cli.py
@@ -9,7 +9,7 @@ from .repl import Repl
 from ..__init__ import __version__
 from ..api.app import create_app as create_api_app
 from ..commands.device import get_device_info
-from ..commands.mobile_packages import patch_ios_ipa, patch_android_apk
+from ..commands.mobile_packages import patch_ios_ipa, patch_android_apk, sign_android_apk
 from ..commands.plugin_manager import load_plugin
 from ..state.app import app_state
 from ..state.connection import state_connection
@@ -365,6 +365,16 @@ def patchapk(source: str, architecture: str, gadget_version: str, pause: bool, s
 
     patch_android_apk(**locals())
 
+@cli.command()
+@click.argument('sources', nargs=-1, type=click.Path(exists=True), required=True)
+@click.option('--skip-cleanup', '-k', is_flag=True,
+              help='Do not clean temporary files once finished.', show_default=True)
+def signapk(sources, skip_cleanup: bool) -> None:
+    """
+        Zipalign and sign an APK with the objection key.
+    """
+    for source in sources:
+        sign_android_apk(source, skip_cleanup)
 
 if __name__ == '__main__':
     cli()

--- a/objection/utils/patchers/android.py
+++ b/objection/utils/patchers/android.py
@@ -4,6 +4,7 @@ import shutil
 import tempfile
 import xml.etree.ElementTree as ElementTree
 from pkg_resources import parse_version
+import contextlib
 
 import click
 import delegator
@@ -186,8 +187,8 @@ class AndroidPatcher(BasePlatformPatcher):
         'adb': {
             'installation': 'apt install adb (Kali Linux); brew install adb (macOS)'
         },
-        'jarsigner': {
-            'installation': 'apt install default-jdk (Linux); brew cask install java (macOS)'
+        'apksigner': {
+            'apksigner': 'apt install apksigner (Kali Linux)'
         },
         'apktool': {
             'installation': 'apt install apktool (Kali Linux)'
@@ -873,7 +874,7 @@ class AndroidPatcher(BasePlatformPatcher):
             self.required_commands['zipalign']['location'],
             '-p',
             '4',
-            self.apk_temp_frida_patched,
+            self.apk_temp_frida_patched if os.path.exists(self.apk_temp_frida_patched) else self.apk_source,
             self.apk_temp_frida_patched_aligned
         ]))
 
@@ -898,22 +899,18 @@ class AndroidPatcher(BasePlatformPatcher):
         click.secho('Signing new APK.', dim=True)
 
         o = delegator.run(self.list2cmdline([
-            self.required_commands['jarsigner']['location'],
-            '-sigalg',
-            'SHA1withRSA',
-            '-digestalg',
-            'SHA1',
-            '-tsa',
-            'http://timestamp.digicert.com',
-            '-storepass',
-            'basil-joule-bug',
-            '-keystore',
+            self.required_commands['apksigner']['location'],
+            'sign',
+            '--ks',
             self.keystore,
-            self.apk_temp_frida_patched,
-            'objection'
+            '--ks-pass',
+            'pass:basil-joule-bug',
+            '--ks-key-alias',
+            'objection',
+            self.apk_temp_frida_patched_aligned
         ]))
 
-        if len(o.err) > 0 or 'jar signed' not in o.out:
+        if len(o.err) > 0:
             click.secho('Signing the new APK may have failed.', fg='red')
             click.secho(o.out, fg='yellow')
             click.secho(o.err, fg='red')
@@ -936,8 +933,12 @@ class AndroidPatcher(BasePlatformPatcher):
         try:
 
             shutil.rmtree(self.apk_temp_directory, ignore_errors=True)
-            os.remove(self.apk_temp_frida_patched)
-            os.remove(self.apk_temp_frida_patched_aligned)
+            
+            with contextlib.suppress(FileNotFoundError):
+                os.remove(self.apk_temp_frida_patched)
+            
+            with contextlib.suppress(FileNotFoundError):
+                os.remove(self.apk_temp_frida_patched_aligned)
 
         except Exception as err:
             click.secho('Failed to cleanup with error: {0}'.format(err), fg='red', dim=True)


### PR DESCRIPTION
Split APKs consist of a base.apk and additional split_config.*.apk files. In order to use them with objection, the APK which contains the main activity - usually base.apk - has to be patched and the remaining APKs have to be signed (and potentially zipaligned if modified) with objection's signing key.

To simplify this process, I added a new 'objection signapk' command similar to 'objection patchapk'. Handling split APKs is then done as follows:
```
objection patchapk -s base.apk
objection signapk split_*.apk
adb install-multiple *.objection.apk
```