### PR TITLE
Exclude TV leanback launcher activities from launchable activity detection

### DIFF
--- a/objection/utils/patchers/android.py
+++ b/objection/utils/patchers/android.py
@@ -4,6 +4,7 @@ import shutil
 import tempfile
 import xml.etree.ElementTree as ElementTree
 from pkg_resources import parse_version
+import re
 
 import click
 import delegator
@@ -318,20 +319,14 @@ class AndroidPatcher(BasePlatformPatcher):
             :return:
         """
 
-        activity = ''
-        aapt = self._get_appt_output().split('\n')
+        activities = (match.groups()[0] for match in re.finditer(r"^launchable-activity: name='([^']+)'", self._get_appt_output(), re.MULTILINE))
+        activity = next(activities, None)
 
-        for line in aapt:
-            if 'launchable-activity' in line:
-                # ['launchable-activity: name=', 'com.app.activity', '  label=', 'bob']
-                activity = line.split('\'')[1]
-
-        # If we got the activity using aapt, great, return that.
-        if activity != '':
+        # If we got the activity using aapt, great, return that
+        if activity is not None:
             return activity
-
+        
         # if we dont have the activity yet, check out activity aliases
-
         click.secho(('Unable to determine the launchable activity using aapt, trying '
                      'to manually parse the AndroidManifest for activity aliases...'), dim=True, fg='yellow')
 


### PR DESCRIPTION
When trying to detect the launcher activity, objection sometimes identifies a leanback-launchable-activity (Android TV) which is usually not the activity that a user would want to launch the agent from.

Therefore, this pull request limits the detecion to 'normal' launchable activities.

This could still be improved by e.g. injecting in all launchable activities (?), list the launchable activities that where not chosen by objection in case the user wants to specify them manually or look for a 'normal' launchable activity first and if not found, then check for leanback-launchable activities.