### PR TITLE
Added warnings for loaded classes

### DIFF
--- a/objection/commands/android/hooking.py
+++ b/objection/commands/android/hooking.py
@@ -51,7 +51,9 @@ def _should_dump_return_value(args: list) -> bool:
 
 def show_android_classes(args: list = None) -> None:
     """
-        Show the currently loaded classes.
+        Show the currently loaded classes. 
+        Note that Java classes are only loaded when they are used, 
+        so not all classes may be present.
 
         :param args:
         :return:
@@ -244,7 +246,9 @@ def set_method_return_value(args: list = None) -> None:
 
 def search_class(args: list) -> None:
     """
-        Searches the current Android application for a class.
+        Searches the currently loaded classes for a class.
+        Note that Java classes are only loaded when they are used, 
+        so if you don't get results, the class might not have been used yet.
 
         :param args:
         :return:
@@ -253,6 +257,9 @@ def search_class(args: list) -> None:
     if len(clean_argument_flags(args)) < 1:
         click.secho('Usage: android hooking search classes <name>', bold=True)
         return
+
+    click.secho('Note that Java classes are only loaded when they are used,' 
+        ' so if the expected class has not been found, it might not have been loaded yet.', fg='yellow')
 
     search = args[0]
     found = 0
@@ -285,6 +292,9 @@ def search_methods(args: list) -> None:
     search = args[0]
     class_filter = args[1] if len(clean_argument_flags(args)) > 1 else None
     found = 0
+
+    click.secho('Note that Java classes are only loaded when they are used,' 
+        ' so if the expected class has not been found, it might not have been loaded yet.', fg='yellow')
 
     if not class_filter:
         click.secho('Warning, searching all classes may take some time and in some cases, '

--- a/tests/commands/android/test_hooking.py
+++ b/tests/commands/android/test_hooking.py
@@ -241,7 +241,7 @@ Fragment: bar
         with capture(search_class, ['com.foo.bar']) as o:
             output = o
 
-        self.assertEqual(output, '\nFound 0 classes\n')
+        self.assertEqual(output, 'Note that Java classes are only loaded when they are used, so if the expected class has not been found, it might not have been loaded yet.\n\nFound 0 classes\n')
 
     @mock.patch('objection.state.connection.state_connection.get_api')
     def test_search_class(self, mock_api):
@@ -253,7 +253,8 @@ Fragment: bar
         with capture(search_class, ['com.foo.bar']) as o:
             output = o
 
-        expected_output = """com.foo.bar
+        expected_output = """Note that Java classes are only loaded when they are used, so if the expected class has not been found, it might not have been loaded yet.
+com.foo.bar
 com.foo.bar.baz
 
 Found 2 classes
@@ -279,7 +280,8 @@ Found 2 classes
         with capture(search_methods, ['hteeteepee']) as o:
             output = o
 
-        expected_output = """Warning, searching all classes may take some time and in some cases, crash the target application.
+        expected_output = """Note that Java classes are only loaded when they are used, so if the expected class has not been found, it might not have been loaded yet.
+Warning, searching all classes may take some time and in some cases, crash the target application.
 Found 0 classes, searching methods (this may take some time)...
 
 Found 0 methods
@@ -295,7 +297,8 @@ Found 0 methods
         with capture(search_methods, ['hteeteepee', 'com.foo']) as o:
             output = o
 
-        expected_output = """Found 0 classes, searching methods (this may take some time)...
+        expected_output = """Note that Java classes are only loaded when they are used, so if the expected class has not been found, it might not have been loaded yet.
+Found 0 classes, searching methods (this may take some time)...
 Filtering classes with com.foo
 
 Found 0 methods
@@ -315,7 +318,8 @@ Found 0 methods
         with capture(search_methods, ['hteeteepee']) as o:
             output = o
 
-        expected_output = """Warning, searching all classes may take some time and in some cases, crash the target application.
+        expected_output = """Note that Java classes are only loaded when they are used, so if the expected class has not been found, it might not have been loaded yet.
+Warning, searching all classes may take some time and in some cases, crash the target application.
 Found 1 classes, searching methods (this may take some time)...
 invoke_hteeteepee_method
 
@@ -338,7 +342,8 @@ Found 1 methods
         with capture(search_methods, ['hteeteepee', 'com.test']) as o:
             output = o
 
-        expected_output = """Found 2 classes, searching methods (this may take some time)...
+        expected_output = """Note that Java classes are only loaded when they are used, so if the expected class has not been found, it might not have been loaded yet.
+Found 2 classes, searching methods (this may take some time)...
 Filtering classes with com.test
 invoke_hteeteepee_method
 


### PR DESCRIPTION
Not all Java classes are available when the application is loaded. While this is technically an ART/Frida limitation, it might still be nice to inform the user of this potentially unexpected behavior.