### PR TITLE
Objection patchapk manual manifest

### DIFF
--- a/objection/commands/mobile_packages.py
+++ b/objection/commands/mobile_packages.py
@@ -98,7 +98,7 @@ def patch_android_apk(source: str, architecture: str, pause: bool, skip_cleanup:
                       enable_debug: bool = True, gadget_version: str = None, skip_resources: bool = False,
                       network_security_config: bool = False, target_class: str = None,
                       use_aapt2: bool = False, gadget_config: str = None, script_source: str = None,
-                      ignore_nativelibs: bool = True) -> None:
+                      ignore_nativelibs: bool = True, manifest: str = None) -> None:
     """
         Patches an Android APK by extracting, patching SMALI, repackaging
         and signing a new APK.
@@ -115,6 +115,7 @@ def patch_android_apk(source: str, architecture: str, pause: bool, skip_cleanup:
         :param use_aapt2:
         :param gadget_config:
         :param script_source:
+        :param manifest:
 
         :return:
     """
@@ -172,7 +173,7 @@ def patch_android_apk(source: str, architecture: str, pause: bool, skip_cleanup:
 
     click.secho('Patcher will be using Gadget version: {0}'.format(github_version), fg='green')
 
-    patcher = AndroidPatcher(skip_cleanup=skip_cleanup, skip_resources=skip_resources)
+    patcher = AndroidPatcher(skip_cleanup=skip_cleanup, skip_resources=skip_resources, manifest=manifest)
 
     # ensure that we have all of the commandline requirements
     if not patcher.are_requirements_met():

--- a/objection/console/cli.py
+++ b/objection/console/cli.py
@@ -345,9 +345,10 @@ def patchipa(source: str, gadget_version: str, codesign_signature: str, provisio
                     'Specify "libfrida-gadget.script.so" as the "path" in your config.'), show_default=False)
 @click.option('--ignore-nativelibs', '-n', is_flag=True, default=False,
               help=('Do not change the extractNativeLibs flag in the AndroidManifest.xml.'), show_default=False)
+@click.option('--manifest', '-m', help='The manual manifest file to read.', default=None)
 def patchapk(source: str, architecture: str, gadget_version: str, pause: bool, skip_cleanup: bool,
              enable_debug: bool, skip_resources: bool, network_security_config: bool, target_class: str,
-             use_aapt2: bool, gadget_config: str, script_source: str, ignore_nativelibs: bool) -> None:
+             use_aapt2: bool, gadget_config: str, script_source: str, ignore_nativelibs: bool, manifest: str) -> None:
     """
         Patch an APK with the frida-gadget.so.
     """

--- a/objection/utils/patchers/android.py
+++ b/objection/utils/patchers/android.py
@@ -198,7 +198,7 @@ class AndroidPatcher(BasePlatformPatcher):
         }
     }
 
-    def __init__(self, skip_cleanup: bool = False, skip_resources: bool = False):
+    def __init__(self, skip_cleanup: bool = False, skip_resources: bool = False, manifest: str = None):
         super(AndroidPatcher, self).__init__()
 
         self.apk_source = None
@@ -208,6 +208,7 @@ class AndroidPatcher(BasePlatformPatcher):
         self.aapt = None
         self.skip_cleanup = skip_cleanup
         self.skip_resources = skip_resources
+        self.manifest = manifest
 
         self.keystore = os.path.join(os.path.abspath(os.path.dirname(__file__)), '../assets', 'objection.jks')
         self.netsec_config = os.path.join(os.path.abspath(os.path.dirname(__file__)), '../assets',
@@ -281,15 +282,17 @@ class AndroidPatcher(BasePlatformPatcher):
         """
 
         # error if --skip-resources was used because the manifest is encoded
-        if self.skip_resources is True:
+        if self.skip_resources is True and self.manifest is None:
             click.secho('Cannot manually parse the AndroidManifest.xml when --skip-resources '
-                        'is set, remove this and try again.', fg='red')
+                        'is set, remove this and try again, or manually specify manifest with --manifest.', fg='red')
             raise Exception('Cannot --skip-resources when trying to manually parse the AndroidManifest.xml')
 
         # use the android namespace
         ElementTree.register_namespace('android', 'http://schemas.android.com/apk/res/android')
-
-        return ElementTree.parse(os.path.join(self.apk_temp_directory, 'AndroidManifest.xml'))
+        if self.manifest is not None:
+            return ElementTree.parse(self.manifest)
+        else:
+            return ElementTree.parse(os.path.join(self.apk_temp_directory, 'AndroidManifest.xml'))
 
     def _get_appt_output(self):
         """


### PR DESCRIPTION
Added code to allow for a decoded manifest file to be specified when using the "--skip-resources" flag.  Normally, the manifest file that is extracted is not decoded automatically when using that flag, and as a result it cannot be parsed to determine classes to inject into.  By using this new "--manifest" flag, you can specify a manifest file you have extracted manually in another program and have Objection automatically determine the target class, even if apktool normally crashes when extracting resources.