### PR TITLE
Fix typo in ios jailbreak disable command usage

### DIFF
--- a/objection/console/helpfiles/ios.jailbreak.disable.txt
+++ b/objection/console/helpfiles/ios.jailbreak.disable.txt
@@ -5,7 +5,7 @@ Usage: ios jailbreak disable
 Attempts to disable Jailbreak detection on iOS devices. This is achieved by
 hooking the NSFileManager fileExistsAtPath method, and checking if it was
 called with a path to common Jailbroken path artifacts. Calls to the fork()
-method are also hooked and will respond with a 0, indicating that it was
+method are also hooked and will respond with a -1, indicating that it was
 unsuccessful.
 
 Examples:


### PR DESCRIPTION
The "failure" code is -1, which is what objection replaces the return value with, not 0.