### PR TITLE
Added command to setup proxy via objection

### DIFF
--- a/agent/src/android/proxy.ts
+++ b/agent/src/android/proxy.ts
@@ -1,0 +1,26 @@
+import { wrapJavaPerform } from "./lib/libjava";
+import { colors as c } from "../lib/color";
+import { qsend } from "../lib/helpers";
+
+export namespace proxy {
+
+  export const set = (host: string, port: string): Promise<void> => {
+    return wrapJavaPerform(() => {
+      var proxyHost = host;
+      var proxyPort = port;
+
+      var System = Java.use("java.lang.System");
+
+      if(System != undefined) {
+        send(c.green(`Setting properties for a proxy`));
+        System.setProperty("http.proxyHost", proxyHost);
+        System.setProperty("http.proxyPort", proxyPort);
+
+        System.setProperty("https.proxyHost", proxyHost);
+        System.setProperty("https.proxyPort", proxyPort);
+
+        send(`${c.green(`Proxy configured to ` + proxyHost + ` ` + proxyPort)}`);
+      }
+    });
+  };
+}

--- a/agent/src/rpc/android.ts
+++ b/agent/src/rpc/android.ts
@@ -10,6 +10,7 @@ import { sslpinning } from "../android/pinning";
 import { root } from "../android/root";
 import { androidshell } from "../android/shell";
 import { userinterface } from "../android/userinterface";
+import { proxy } from "../android/proxy";
 
 export const android = {
   // android clipboard
@@ -63,6 +64,9 @@ export const android = {
 
   // android ssl pinning
   androidSslPinningDisable: (quiet: boolean) => sslpinning.disable(quiet),
+
+  // android proxy set/unset
+  androidProxySet: (host: string, port: string): Promise<void> => proxy.set(host, port),
 
   // android root detection
   androidRootDetectionDisable: () => root.disable(),

--- a/objection/commands/android/proxy.py
+++ b/objection/commands/android/proxy.py
@@ -1,0 +1,18 @@
+import click
+from objection.state.connection import state_connection
+
+
+def android_proxy_set(args: list = None) -> None:
+    """
+        Sets a proxy specifically within the application.
+
+        :param args:
+        :return:
+    """
+
+    if len(args) != 2:
+        click.secho('Usage: android proxy set <ip address> <port>', bold=True)
+        return
+
+    api = state_connection.get_api()
+    api.android_proxy_set(args[0], args[1])

--- a/objection/console/commands.py
+++ b/objection/console/commands.py
@@ -17,6 +17,7 @@ from ..commands.android import hooking as android_hooking
 from ..commands.android import intents
 from ..commands.android import keystore
 from ..commands.android import pinning as android_pinning
+from ..commands.android import proxy as android_proxy
 from ..commands.android import root
 from ..commands.ios import binary
 from ..commands.ios import bundles
@@ -467,6 +468,15 @@ COMMANDS = {
                         'meta': 'Attempt to disable SSL pinning in various Java libraries/classes',
                         'flags': ['--quiet'],
                         'exec': android_pinning.android_disable
+                    }
+                }
+            },
+            'proxy': {
+                'meta': 'Commands to work with a proxy for the application',
+                'commands': {
+                    'set': {
+                        'meta': 'Set a proxy for the application',
+                        'exec': android_proxy.android_proxy_set
                     }
                 }
             },


### PR DESCRIPTION
Having to setup a proxy manually has always been a pain. We can set this via frida, added a command to objection to allow us to do so. 

I initially found the code in https://github.com/smartdone/Frida-Scripts/tree/master/proxy, used the same approach in objection. 