### PR TITLE
(fix) keychain dumper misses entries with kSecAttrSynchronizable=true

### DIFF
--- a/agent/src/ios/keychain.ts
+++ b/agent/src/ios/keychain.ts
@@ -67,6 +67,7 @@ export namespace ioskeychain {
     searchDictionary.setObject_forKey_(kCFBooleanTrue, kSec.kSecReturnData);
     searchDictionary.setObject_forKey_(kCFBooleanTrue, kSec.kSecReturnRef);
     searchDictionary.setObject_forKey_(kSec.kSecMatchLimitAll, kSec.kSecMatchLimit);
+    searchDictionary.setObject_forKey_(kSec.kSecAttrSynchronizableAny, kSec.kSecAttrSynchronizable);
 
     // loop each of the keychain class types and extract data
     const itemClassResults: IKeychainData[][] = itemClasses.map((clazz) => {

--- a/agent/src/ios/keychain.ts
+++ b/agent/src/ios/keychain.ts
@@ -151,6 +151,7 @@ export namespace ioskeychain {
   // clean out the keychain
   export const empty = (): void => {
     const searchDictionary: NSMutableDictionaryType = ObjC.classes.NSMutableDictionary.alloc().init();
+    searchDictionary.setObject_forKey_(kSec.kSecAttrSynchronizableAny, kSec.kSecAttrSynchronizable);
     itemClasses.forEach((clazz) => {
 
       // set the class-type we are querying for now & delete

--- a/agent/src/ios/lib/constants.ts
+++ b/agent/src/ios/lib/constants.ts
@@ -28,6 +28,7 @@ export enum kSec {
   kSecAttrAccessControl = "accc",
   kSecAttrGeneric = "gena",
   kSecAttrSynchronizable = "sync",
+  kSecAttrSynchronizableAny = "syna",
   kSecAttrModificationDate = "mdat",
   kSecAttrServer = "srvr",
   kSecAttrDescription = "desc",


### PR DESCRIPTION
In a practical test with an iOS app on iOS 14.4 I discovered that the keychain dumper does not dump all keychain entries.

In detail all keychain entries were missing that had been created using the option `query[kSecAttrSynchronizable]=kCFBooleanTrue`.

This behavior can be changed by adding `query[kSecAttrSynchronizable]=kSecAttrSynchronizableAny` to the keychain query. The present pull requests contains these changes so the keychain dumper can return all entries no matter if `kSecAttrSynchronizable` has been set to true or false (the latter is the default value).

Tested on iOS 14.4

Edit: The function for deleting all keychain entries was also ignoring entries with query[kSecAttrSynchronizable]=kCFBooleanTrue`. I have added a commit that changes the `empty()` method to also delete such entries.
