### PR TITLE
Added Command Android>Keystore>ListDetails

### DIFF
--- a/agent/src/rpc/android.ts
+++ b/agent/src/rpc/android.ts
@@ -64,6 +64,7 @@ export const android = {
   // android keystore
   androidKeystoreClear: () => keystore.clear(),
   androidKeystoreList: (): Promise<IKeyStoreEntry[]> => keystore.list(),
+  androidKeystoreListDetails: () => keystore.listDetails(),
   androidKeystoreWatch: (): void => keystore.watchKeystore(),
 
   // android ssl pinning

--- a/objection/commands/android/keystore.py
+++ b/objection/commands/android/keystore.py
@@ -19,6 +19,18 @@ def entries(args: list = None) -> None:
     click.secho(tabulate(output, headers=['Alias', 'Key', 'Certificate']))
 
 
+def listDetails(args: list = None) -> None:
+    """
+        Lists details of all items in Android KeyStore
+
+        :param args:
+        :return:
+    """
+    click.secho('List details of all items in Android KeyStore...', dim=True)
+    api = state_connection.get_api()
+    ks = api.android_keystore_list_details()
+
+
 def clear(args: list = None) -> None:
     """
         Clears out an Android KeyStore

--- a/objection/console/commands.py
+++ b/objection/console/commands.py
@@ -422,6 +422,10 @@ COMMANDS = {
                         'meta': 'Lists entries in the Android KeyStore',
                         'exec': keystore.entries
                     },
+                    'listDetails': {
+                        'meta': 'Lists details of all items in Android KeyStore',
+                        'exec': keystore.listDetails
+                    },
                     'clear': {
                         'meta': 'Clears the Android KeyStore',
                         'exec': keystore.clear

--- a/objection/console/helpfiles/android.keystore.listdetails.txt
+++ b/objection/console/helpfiles/android.keystore.listdetails.txt
@@ -1,0 +1,10 @@
+Command: android keystore listDetails
+
+Usage: android keystore listDetails
+
+Lists details of 'AndroidKeyStore' items in of the current application in KeyStore. 
+
+Ref: https://developer.android.com/reference/java/security/KeyStore.html
+
+Examples:
+   android keystore listDetails


### PR DESCRIPTION
Added a command to list Information of Android Keystore Items.

The function `KeystoreInfo` is taken from:
- https://labs.f-secure.com/blog/how-secure-is-your-android-keystore-authentication
- https://github.com/FSecureLABS/android-keystore-audit

Example Output:
![objection](https://user-images.githubusercontent.com/39155277/114700430-c9335c00-9d21-11eb-820b-f77debaa93fa.png)
