### PR TITLE
Implement JailMonkey bypass

### DIFF
--- a/agent/src/android/root.ts
+++ b/agent/src/android/root.ts
@@ -95,6 +95,28 @@ export namespace root {
     });
   };
 
+  const jailMonkeyBypass = (success: boolean, ident: string): any => {
+    return wrapJavaPerform(() => {
+      const JavaJailMonkeyModule = Java.use("com.gantix.JailMonkey.JailMonkeyModule");
+      const JavaHashMap = Java.use("java.util.HashMap");
+      const JavaFalseObject = Java.use("java.lang.Boolean").FALSE.value;
+      JavaJailMonkeyModule.getConstants.implementation = function() {
+        send(
+          c.blackBright(`[${ident}] `) +
+          `JailMonkeyModule.getConstants() called, returning false for all keys.`
+        );
+        const hm = JavaHashMap.$new();
+        hm.put("isJailBroken", false_object);
+        hm.put("hookDetected", false_object);
+        hm.put("canMockLocation", false_object);
+        hm.put("isOnExternalStorage", false_object);
+        hm.put("AdbEnabled", false_object);
+        return hm;
+      };
+      return JavaJailMonkeyModule;
+    });
+  };
+
   export const disable = (): void => {
     const job: IJob = {
       identifier: jobs.identifier(),
@@ -105,6 +127,7 @@ export namespace root {
     job.implementations.push(testKeysCheck(false, job.identifier));
     job.implementations.push(execSuCheck(false, job.identifier));
     job.implementations.push(fileExistsCheck(false, job.identifier));
+    job.implementations.push(jailMonkeyBypass(false, job.identifier));
     jobs.add(job);
   };
 
@@ -118,6 +141,7 @@ export namespace root {
     job.implementations.push(testKeysCheck(true, job.identifier));
     job.implementations.push(execSuCheck(true, job.identifier));
     job.implementations.push(fileExistsCheck(true, job.identifier));
+    job.implementations.push(jailMonkeyBypass(true, job.identifier));
     jobs.add(job);
   };
 }

--- a/agent/src/ios/jailbreak.ts
+++ b/agent/src/ios/jailbreak.ts
@@ -278,6 +278,17 @@ export namespace iosjailbreak {
     });
   };
 
+  const jailMonkeyBypass = (success: boolean, ident: string): InvocationListener => {
+    return Interceptor.attach(ObjC.classes.JailMonkey["- isJailBroken"].implementation, {
+      onLeave(retval) {
+        send(
+          c.blackBright(`[${ident}] `) + `JailMonkey.isJailBroken called, returning false.`
+        );
+        retval.replace(new NativePointer(0x00));
+      }
+    });
+  };
+
   export const disable = (): void => {
     const job: IJob = {
       identifier: jobs.identifier(),
@@ -289,6 +300,7 @@ export namespace iosjailbreak {
     job.invocations.push(libSystemBFork(false, job.identifier));
     job.invocations.push(fopen(false, job.identifier));
     job.invocations.push(canOpenURL(false, job.identifier));
+    job.invocations.push(jailMonkeyBypass(false, job.identifier));
 
     jobs.add(job);
   };
@@ -304,6 +316,7 @@ export namespace iosjailbreak {
     job.invocations.push(libSystemBFork(true, job.identifier));
     job.invocations.push(fopen(true, job.identifier));
     job.invocations.push(canOpenURL(true, job.identifier));
+    job.invocations.push(jailMonkeyBypass(true, job.identifier));
 
     jobs.add(job);
   };


### PR DESCRIPTION
The React Native library "JailMonkey" implements some root/Jailbreak detection stuff beyond what `objection` already bypasses. A blog post by Ayrx details bypasses for this library here: https://www.ayrx.me/gantix-jailmonkey-root-detection-bypass.

This PR just adds those bypasses into the Android and iOS agents for `objection`. I'm currently using both on the mobile app pentest I'm delivering and they appear to be working fine.