### PR TITLE
Removed references to v8 and fixed console command help

### DIFF
--- a/objection/console/commands.py
+++ b/objection/console/commands.py
@@ -396,14 +396,14 @@ COMMANDS = {
                         }
                     },
                     'print': {
-                        'meta': 'Print information about objects on the iOS heap',
+                        'meta': 'Print information about objects on the heap',
                         'commands': {
                             'fields': {
                                 'meta': 'Print instance fields for a Java object handle',
                                 'exec': android_heap.fields
                             },
                             'methods': {
-                                'meta': 'Print instance methods for an Android handle',
+                                'meta': 'Print instance methods for a Java object handle',
                                 'flags': ['--without-arguments'],
                                 'exec': android_heap.methods
                             }

--- a/objection/utils/assets/javahookmanager.js
+++ b/objection/utils/assets/javahookmanager.js
@@ -2,7 +2,7 @@
 //
 // Edit the example below the HookManager class to suit your
 // needs and then run with:
-//  frida -U "App Name" --runtime=v8 -l objchookmanager.js
+//  frida -U "App Name" -l objchookmanager.js
 //
 // Generated using objection:
 //  https://github.com/sensepost/objection

--- a/objection/utils/assets/objchookmanager.js
+++ b/objection/utils/assets/objchookmanager.js
@@ -2,7 +2,7 @@
 //
 // Edit the example below the HookManager class to suit your
 // needs and then run with:
-//  frida -U "App Name" --runtime=v8 -l objchookmanager.js
+//  frida -U "App Name" -l objchookmanager.js
 //
 // Generated using objection:
 //  https://github.com/sensepost/objection


### PR DESCRIPTION
Hi there, some very small changes. 

* I removed references to `--runtime=v8` when generating hooks because with the newer versions of Frida it doesn't matter. 
* The `android hooking search` command help had a reference to iOS.

Kindly let me know if there's anything else I can change and thank you for Objection!