### PR TITLE
Feat android enumerate

### DIFF
--- a/agent/src/android/hooking.ts
+++ b/agent/src/android/hooking.ts
@@ -1,4 +1,3 @@
-import { rejects } from "assert";
 import { colors as c } from "../lib/color";
 import { IJob } from "../lib/interfaces";
 import { jobs } from "../lib/jobs";
@@ -178,7 +177,7 @@ export namespace hooking {
   export const getClassMethodsOverloads = (className: string, methodsAllowList: string[] = [], loader?: string): Promise<JSON> => {
     return wrapJavaPerform(() => {
       const result: any = {} // TODO(cduplooy): Properly type this.
-      const clazz = loader !== null ? getClassHandleWithLoaderClassName(className, loader) : getClassHandle(className)
+      const clazz = loader !== null ? getClassHandleWithLoaderClassName(className, loader) : Java.use(className)
 
       if (clazz === null) {
         throw new Error("Could not find class!");

--- a/agent/src/android/hooking.ts
+++ b/agent/src/android/hooking.ts
@@ -67,6 +67,10 @@ export namespace hooking {
     }
   }
   export const enumerate = (query: string): Promise<EnumerateMethodsMatchGroup[]> => {
+    // If the query is just a classname, strongarm it into a pattern. 
+    if (getPatternType(query) === PatternType.Klass){
+      query = `${query}!*`
+    }
     return wrapJavaPerform(() => {
           return Java.enumerateMethods(query);
         }

--- a/agent/src/android/hooking.ts
+++ b/agent/src/android/hooking.ts
@@ -19,6 +19,7 @@ import {
 
 export namespace hooking {
 
+  import EnumerateMethodsMatchGroup = Java.EnumerateMethodsMatchGroup;
   const splitClassMethod = (fqClazz: string): string[] => {
     // split a fully qualified class name, assuming the last period denotes the method
     const methodSeperatorIndex: number = fqClazz.lastIndexOf(".");
@@ -37,19 +38,27 @@ export namespace hooking {
 
   export const getClassLoaders = (): Promise<string[]> => {
     return wrapJavaPerform(() => {
-      let loaders: string[] = [];
+      const loaders: string[] = [];
       Java.enumerateClassLoaders({
-        onMatch: function (l) {
+        onMatch (l) {
           if (l == null) {
             return;
           }
           loaders.push(l.toString());
         },
-        onComplete: function () { }
+        onComplete () { }
       });
 
       return loaders;
     });
+  };
+
+
+  export const enumerate = (query: string): Promise<EnumerateMethodsMatchGroup[]> => {
+    return wrapJavaPerform(() => {
+          return Java.enumerateMethods(query);
+        }
+    );
   };
 
   export const getClassMethods = (className: string): Promise<string[]> => {

--- a/agent/src/android/hooking.ts
+++ b/agent/src/android/hooking.ts
@@ -105,7 +105,7 @@ export namespace hooking {
       return result
     });
   };
-
+  // TODO (cduplooy): Add additional arguments here
   export const watchClass = (clazz: string): Promise<void> => {
     return wrapJavaPerform(() => {
       const clazzInstance: JavaClass = Java.use(clazz);
@@ -150,6 +150,7 @@ export namespace hooking {
 
           // replace the implementation of this method
           // tslint:disable-next-line:only-arrow-functions
+          // TODO: (cduplooy): Add dump-args and dump-return valuie
           m.implementation = function () {
             send(
               c.blackBright(`[${job.identifier}] `) +

--- a/agent/src/index.ts
+++ b/agent/src/index.ts
@@ -4,6 +4,7 @@ import { env } from "./rpc/environment";
 import { ios } from "./rpc/ios";
 import { jobs } from "./rpc/jobs";
 import { memory } from "./rpc/memory";
+import { native } from "./rpc/native";
 import { other } from "./rpc/other";
 
 rpc.exports = {
@@ -13,5 +14,6 @@ rpc.exports = {
   ...jobs,
   ...memory,
   ...other,
+  ...native,
   ping: (): boolean => ping(),
 };

--- a/agent/src/ios/hooking.ts
+++ b/agent/src/ios/hooking.ts
@@ -21,8 +21,8 @@ export namespace hooking {
     return ObjC.classes[className].$ownMethods;
   };
   export const enumerate = (pattern: string): ApiResolverMatch[] => {
-      const resolver = new ApiResolver('objc')
-      return resolver.enumerateMatches(pattern)
+    const resolver = new ApiResolver('objc')
+    return resolver.enumerateMatches(pattern)
   };
   export const searchMethods = (partial: string): string[] => {
     const results: string[] = []; // the response
@@ -38,7 +38,7 @@ export namespace hooking {
 
     return results;
   };
-  export const watchClass = (clazz: string, parents: boolean): void => {
+  export const watchClass = (clazz: string, dargs: boolean = false, dbt: boolean = false, dret: boolean = false, parents: boolean = false): void => {
     const target = ObjC.classes[clazz];
 
     if (!target) {
@@ -55,36 +55,34 @@ export namespace hooking {
 
     // with parents as true, include methods from a parent class,
     // otherwise simply hook the target class' own  methods
-    const watchInvocations = (parents ? target.$methods : target.$ownMethods).map((method) => {
+    (parents ? target.$methods : target.$ownMethods).forEach((method) => {
       // filter and make sure we have a type and name. Looks like some methods can
       // have '' as name... am expecting something like "- isJailBroken"
-      if (method.split(" ").length !== 2) {
-        send(
-          c.red(`Skipping method `) + `${c.greenBright(`'` + method + `'`)}` +
-          c.red(`, does not match <type> <name> format`));
-        return;
-      }
-
-      send(c.blackBright(`Watching method: ${c.greenBright(method)}`));
-      return Interceptor.attach(target[method].implementation, {
-        onEnter: (args) => {
-          const receiver = new ObjC.Object(args[0]);
-          send(
-            c.blackBright(`[${job.identifier}] `) +
-            `Called: ${c.green(`[${receiver.$className} ${ObjC.selectorAsString(args[1])}]`)} ` +
-            `(Kind: ${c.cyan(receiver.$kind)}) (Super: ${c.cyan(receiver.$superClass.$className)})`,
-          );
-        },
-      });
+      const fullMethodName = `${method[0]}[${clazz} ${method.substring(2)}]`
+      watchMethod(fullMethodName, dargs, dbt, dret)
     });
 
-    // register the job
-    watchInvocations.forEach((invocation) => {
-      job.invocations.push(invocation);
-    });
-    jobs.add(job);
   };
-
+  export const search = (patternOrClass: string): ApiResolverMatch[] => {
+    const isPattern = patternOrClass.includes('[')
+    if (isPattern === false) {
+      // Make a pattern
+      return enumerate(`*[${patternOrClass} *]`)
+    } else {
+      return enumerate(patternOrClass)
+    }
+  }
+  export const watch = (patternOrClass: string, dargs: boolean = false, dbt: boolean = false, dret: boolean = false, watchParents: boolean = false): void => {
+    const isPattern = patternOrClass.includes('[')
+    if (isPattern === true) {
+      const matches = enumerate(patternOrClass)
+      matches.forEach((match: ApiResolverMatch) => {
+        watchMethod(match.name, dargs, dbt, dret)
+      })
+    } else {
+      watchClass(patternOrClass, dargs, dbt, dret, watchParents)
+    }
+  }
   export const watchMethod = (selector: string, dargs: boolean, dbt: boolean, dret: boolean): void => {
     const resolver = new ApiResolver("objc");
     let matchedMethod = {

--- a/agent/src/ios/hooking.ts
+++ b/agent/src/ios/hooking.ts
@@ -20,7 +20,10 @@ export namespace hooking {
 
     return ObjC.classes[className].$ownMethods;
   };
-
+  export const enumerate = (pattern: string): ApiResolverMatch[] => {
+      const resolver = new ApiResolver('objc')
+      return resolver.enumerateMatches(pattern)
+  };
   export const searchMethods = (partial: string): string[] => {
     const results: string[] = []; // the response
 
@@ -35,7 +38,6 @@ export namespace hooking {
 
     return results;
   };
-
   export const watchClass = (clazz: string, parents: boolean): void => {
     const target = ObjC.classes[clazz];
 

--- a/agent/src/native/hooking.ts
+++ b/agent/src/native/hooking.ts
@@ -1,0 +1,6 @@
+export namespace hooking{
+    export const search = (query: string): ApiResolverMatch[] => {
+        const resolver = new ApiResolver('module')
+        return resolver.enumerateMatches(query)
+    }
+}

--- a/agent/src/rpc/android.ts
+++ b/agent/src/rpc/android.ts
@@ -20,6 +20,7 @@ import { androidshell } from "../android/shell";
 import { userinterface } from "../android/userinterface";
 import { proxy } from "../android/proxy";
 import { general } from "../android/general";
+import EnumerateMethodsMatchGroup = Java.EnumerateMethodsMatchGroup;
 
 export const android = {
   // android clipboard
@@ -56,6 +57,7 @@ export const android = {
   androidHookingWatchMethod: (fqClazz: string, filterOverload: string | null, dargs: boolean,
     dbt: boolean, dret: boolean): Promise<void> =>
     hooking.watchMethod(fqClazz, filterOverload, dargs, dbt, dret),
+  androidHookingEnumerate: (query: string): Promise<EnumerateMethodsMatchGroup[]> => hooking.enumerate(query),
 
   // android heap methods
   androidHeapEvaluateHandleMethod: (handle: number, js: string): Promise<void> => heap.evaluate(handle, js),

--- a/agent/src/rpc/android.ts
+++ b/agent/src/rpc/android.ts
@@ -61,7 +61,8 @@ export const android = {
     dbt: boolean, dret: boolean): Promise<void> =>
     hooking.watchMethod(fqClazz, filterOverload, dargs, dbt, dret),
   androidHookingEnumerate: (query: string): Promise<EnumerateMethodsMatchGroup[]> => hooking.enumerate(query),
-
+  androidHookingLazyWatchForPattern: (query: string): void => hooking.lazyWatchForPattern(query),
+  
   // android heap methods
   androidHeapEvaluateHandleMethod: (handle: number, js: string): Promise<void> => heap.evaluate(handle, js),
   androidHeapExecuteHandleMethod: (handle: number, method: string, returnString: boolean): Promise<string | null> =>

--- a/agent/src/rpc/android.ts
+++ b/agent/src/rpc/android.ts
@@ -55,7 +55,7 @@ export const android = {
   androidHookingSetMethodReturn: (fqClazz: string, filterOverload: string | null, ret: boolean) =>
     hooking.setReturnValue(fqClazz, filterOverload, ret),
   androidHookingWatch: (pattern: string, watchArgs: boolean, watchBacktrace: boolean, watchRet: boolean): Promise<void> =>
-      hooking.watch(pattern, watchArgs, watchBacktrace, watchRet),
+    hooking.watch(pattern, watchArgs, watchBacktrace, watchRet),
   androidHookingWatchClass: (clazz: string): Promise<void> => hooking.watchClass(clazz),
   androidHookingWatchMethod: (fqClazz: string, filterOverload: string | null, dargs: boolean,
     dbt: boolean, dret: boolean): Promise<void> =>

--- a/agent/src/rpc/android.ts
+++ b/agent/src/rpc/android.ts
@@ -45,6 +45,7 @@ export const android = {
 
   // android hooking
   androidHookingGetClassMethods: (className: string): Promise<string[]> => hooking.getClassMethods(className),
+  androidHookingGetClassMethodsOverloads: (className: string): Promise<JSON> => hooking.getClassMethodsOverloads(className),
   androidHookingGetClasses: (): Promise<string[]> => hooking.getClasses(),
   androidHookingGetClassLoaders: (): Promise<string[]> => hooking.getClassLoaders(),
   androidHookingGetCurrentActivity: (): Promise<ICurrentActivityFragment> => hooking.getCurrentActivity(),

--- a/agent/src/rpc/android.ts
+++ b/agent/src/rpc/android.ts
@@ -54,6 +54,8 @@ export const android = {
   androidHookingListServices: (): Promise<string[]> => hooking.getServices(),
   androidHookingSetMethodReturn: (fqClazz: string, filterOverload: string | null, ret: boolean) =>
     hooking.setReturnValue(fqClazz, filterOverload, ret),
+  androidHookingWatch: (pattern: string, watchArgs: boolean, watchBacktrace: boolean, watchRet: boolean): Promise<void> =>
+      hooking.watch(pattern, watchArgs, watchBacktrace, watchRet),
   androidHookingWatchClass: (clazz: string): Promise<void> => hooking.watchClass(clazz),
   androidHookingWatchMethod: (fqClazz: string, filterOverload: string | null, dargs: boolean,
     dbt: boolean, dret: boolean): Promise<void> =>

--- a/agent/src/rpc/android.ts
+++ b/agent/src/rpc/android.ts
@@ -45,7 +45,7 @@ export const android = {
 
   // android hooking
   androidHookingGetClassMethods: (className: string): Promise<string[]> => hooking.getClassMethods(className),
-  androidHookingGetClassMethodsOverloads: (className: string): Promise<JSON> => hooking.getClassMethodsOverloads(className),
+  androidHookingGetClassMethodsOverloads: (className: string, methodAllowList: string[] = []): Promise<JSON> => hooking.getClassMethodsOverloads(className, methodAllowList),
   androidHookingGetClasses: (): Promise<string[]> => hooking.getClasses(),
   androidHookingGetClassLoaders: (): Promise<string[]> => hooking.getClassLoaders(),
   androidHookingGetCurrentActivity: (): Promise<ICurrentActivityFragment> => hooking.getCurrentActivity(),

--- a/agent/src/rpc/android.ts
+++ b/agent/src/rpc/android.ts
@@ -45,7 +45,7 @@ export const android = {
 
   // android hooking
   androidHookingGetClassMethods: (className: string): Promise<string[]> => hooking.getClassMethods(className),
-  androidHookingGetClassMethodsOverloads: (className: string, methodAllowList: string[] = []): Promise<JSON> => hooking.getClassMethodsOverloads(className, methodAllowList),
+  androidHookingGetClassMethodsOverloads: (className: string, methodAllowList: string[] = [], loader? : string): Promise<JSON> => hooking.getClassMethodsOverloads(className, methodAllowList, loader),
   androidHookingGetClasses: (): Promise<string[]> => hooking.getClasses(),
   androidHookingGetClassLoaders: (): Promise<string[]> => hooking.getClassLoaders(),
   androidHookingGetCurrentActivity: (): Promise<ICurrentActivityFragment> => hooking.getCurrentActivity(),

--- a/agent/src/rpc/ios.ts
+++ b/agent/src/rpc/ios.ts
@@ -61,11 +61,15 @@ export const ios = {
   iosHookingSearchMethods: (partial: string): string[] => hooking.searchMethods(partial),
   iosHookingSetReturnValue: (selector: string, returnVal: boolean): void =>
     hooking.setMethodReturn(selector, returnVal),
+  iosHookingWatch: (pattern: string, dargs: boolean, dbt: boolean, dret: boolean, dparents: boolean) =>
+    hooking.watch(pattern, dargs, dbt, dret, dparents),
   iosHookingWatchClass: (clazz: string, parents: boolean): void => hooking.watchClass(clazz, parents),
   iosHookingWatchMethod: (selector: string, dargs: boolean, dbt: boolean, dret: boolean): void =>
     hooking.watchMethod(selector, dargs, dbt, dret),
   iosHookingEnumerate: (pattern: string): ApiResolverMatch[] =>
-      hooking.enumerate(pattern),
+    hooking.enumerate(pattern),
+  iosHookingSearch: (pattern: string): ApiResolverMatch[] =>
+    hooking.search(pattern),
 
   // ios crypto monitoring
   iosMonitorCryptoEnable: (): void => ioscrypto.monitor(),

--- a/agent/src/rpc/ios.ts
+++ b/agent/src/rpc/ios.ts
@@ -64,6 +64,8 @@ export const ios = {
   iosHookingWatchClass: (clazz: string, parents: boolean): void => hooking.watchClass(clazz, parents),
   iosHookingWatchMethod: (selector: string, dargs: boolean, dbt: boolean, dret: boolean): void =>
     hooking.watchMethod(selector, dargs, dbt, dret),
+  iosHookingEnumerate: (pattern: string): ApiResolverMatch[] =>
+      hooking.enumerate(pattern),
 
   // ios crypto monitoring
   iosMonitorCryptoEnable: (): void => ioscrypto.monitor(),

--- a/agent/src/rpc/native.ts
+++ b/agent/src/rpc/native.ts
@@ -1,0 +1,5 @@
+import { hooking } from "../native/hooking";
+export const native = {
+    nativeSearch: (query: string): ApiResolverMatch[] => hooking.search(query),
+};
+  

--- a/objection/commands/android/hooking.py
+++ b/objection/commands/android/hooking.py
@@ -114,63 +114,20 @@ def show_android_class_methods(args: list = None) -> None:
 
     click.secho('\nFound {0} method(s)'.format(len(methods)), bold=True)
 
-
-def watch_class(args: list) -> None:
-    """
-        Watches for invocations of all methods in an Android
-        Java class. All overloads for methods found are also watched.
-
-        :param args:
-        :return:
-    """
-
+def watch(args: list) -> None:
     if len(clean_argument_flags(args)) < 1:
-        click.secho('Usage: android hooking watch class <class> '
-                    '(eg: com.example.test)', bold=True)
-        return
-
-    target_class = args[0]
-
+        click.secho('Usage: android hooking watch <pattern> '
+                    '(eg: com.example.test, *com.example*!*, com.example.test!toString)'
+                    '(optional: --dump-args) '
+                    '(optional: --dump-backtrace) '
+                    '(optional: --dump-return)'
+                    ,bold=True)
     api = state_connection.get_api()
-
-    if '*' in target_class:
-        classes = api.android_hooking_get_classes()
-        for class_name in fnmatch.filter(classes, target_class):
-            api.android_hooking_watch_class(class_name)
-    else:
-        api.android_hooking_watch_class(target_class)
-
-
-def watch_class_method(args: list) -> None:
-    """
-        Watches for invocations of an Android Java class method.
-        All overloads for the same method are also watched.
-
-        Optionally, this method will dump the watched methods arguments,
-        backtrace as well as return value.
-
-        :param args:
-        :return:
-    """
-
-    if len(clean_argument_flags(args)) < 1:
-        click.secho(('Usage: android hooking watch class_method <fully qualified class method> '
-                     '<optional overload> '
-                     '(optional: --dump-args) '
-                     '(optional: --dump-backtrace) '
-                     '(optional: --dump-return)'), bold=True)
-        return
-
-    fully_qualified_class = args[0]
-    overload_filter = args[1].replace(' ', '') if (len(args) > 1 and '--' not in args[1]) else None
-
-    api = state_connection.get_api()
-    api.android_hooking_watch_method(fully_qualified_class,
-                                     overload_filter,
-                                     _should_dump_args(args),
-                                     _should_dump_backtrace(args),
-                                     _should_dump_return_value(args))
-
+    api.android_hooking_watch(args[0],
+                              _should_dump_args(args),
+                              _should_dump_backtrace(args),
+                              _should_dump_return_value(args)
+                              )
     return
 
 

--- a/objection/commands/android/hooking.py
+++ b/objection/commands/android/hooking.py
@@ -423,7 +423,7 @@ def enumerate(args: list) -> None:
             for _class in result['classes']:
                 _class['overloads'] = api.android_hooking_get_class_methods_overloads(_class['name'])
 
-    if shouldWatchArgs or shouldWatchRet:
+    if shouldWatchArgs or shouldWatchRet or shouldBacktrace:
         for result in results:
             for _class in result['classes']:
                 classname = _class['name']

--- a/objection/commands/android/hooking.py
+++ b/objection/commands/android/hooking.py
@@ -111,6 +111,19 @@ def show_android_class_methods(args: list = None) -> None:
     click.secho('\nFound {0} method(s)'.format(len(methods)), bold=True)
 
 
+
+
+def notify(args: list) -> None:
+    if len(clean_argument_flags(args)) <= 0:
+        click.secho('Usage: android hooking notify $PATTERN', bold=True)
+        return
+
+
+    pattern = args[0]
+
+    api = state_connection.get_api()
+    api.android_hooking_lazy_watch_for_pattern(pattern)
+
 def watch(args: list) -> None:
     if len(clean_argument_flags(args)) < 1:
         click.secho('Usage: android hooking watch <pattern> '

--- a/objection/commands/android/hooking.py
+++ b/objection/commands/android/hooking.py
@@ -416,12 +416,11 @@ def enumerate(args: list) -> None:
 
     api = state_connection.get_api()
     results = api.android_hooking_enumerate(args[0])
-
     # Only get overloads if this flag is specified, otherwise just enumerating can be kind of slow
     if shouldDumpJSON:
         for result in results:
             for _class in result['classes']:
-                _class['overloads'] = api.android_hooking_get_class_methods_overloads(_class['name'])
+                _class['overloads'] = api.android_hooking_get_class_methods_overloads(_class['name'], _class['methods'])
 
     if shouldWatchArgs or shouldWatchRet or shouldBacktrace:
         for result in results:

--- a/objection/commands/android/hooking.py
+++ b/objection/commands/android/hooking.py
@@ -424,3 +424,4 @@ def enumerate(args: list) -> None:
     if targetFile:
         with open(targetFile, 'w') as fd:
             fd.write(json.dumps(results))
+            click.secho(f'JSON dumped to {shouldDumpJSON}', bold=True)

--- a/objection/commands/android/hooking.py
+++ b/objection/commands/android/hooking.py
@@ -237,6 +237,7 @@ def _should_be_quiet(args: list) -> bool:
     return '--quiet' in args
 
 
+
 def _should_dump_json(args: list) -> bool:
     return '--json' in args
 

--- a/objection/commands/ios/hooking.py
+++ b/objection/commands/ios/hooking.py
@@ -209,7 +209,6 @@ def watch(args: list) -> None:
     api = state_connection.get_api()
     api.ios_hooking_watch(pattern, should_watch_args, should_backtrace, should_watch_ret, should_watch_parents)
 
-
 def set_method_return_value(args: list) -> None:
     """
         Make an Objective-C method return a specific boolean
@@ -319,7 +318,7 @@ def search(args: list) -> None:
         if data.get(class_name) is not None:
             data[class_name].append(fullname)
         else:
-            data[class_name] = []
+            data[class_name] = [fullname]
 
     # Print the matching methods
     for klass in data.keys():

--- a/objection/commands/ios/hooking.py
+++ b/objection/commands/ios/hooking.py
@@ -337,7 +337,10 @@ def enumerate(args: list) -> None:
 
     shouldPrintOnlyClasses = _should_print_only_classes(args)
     shouldDumpJSON = _should_dump_json(args)
+    shouldWatchArgs = _should_dump_args(args)
+    shouldWatchRet = _should_dump_return_value(args)
     shouldBeQuiet = _should_be_quiet(args)
+    shouldBacktrace = _should_dump_backtrace(args)
 
     api = state_connection.get_api()
     results = api.ios_hooking_enumerate(args[0])
@@ -358,9 +361,15 @@ def enumerate(args: list) -> None:
         methods = data[klass]
         if not shouldBeQuiet:
             print(klass)
-        if not shouldBeQuiet and not shouldPrintOnlyClasses:
-            for method in methods:
+        for method in methods:
+            if not shouldBeQuiet and not shouldPrintOnlyClasses:
                 print(f'\t{method}')
+            if shouldBacktrace or shouldWatchRet or shouldWatchArgs:
+                selector = method
+                api.ios_hooking_watch_method(selector,
+                                             _should_dump_args(args),
+                                             _should_dump_backtrace(args),
+                                             _should_dump_return_value(args))
 
     # TODO: (connordp): If --dump-* is passed; logic!
 

--- a/objection/commands/ios/hooking.py
+++ b/objection/commands/ios/hooking.py
@@ -362,6 +362,8 @@ def enumerate(args: list) -> None:
             for method in methods:
                 print(f'\t{method}')
 
+    # TODO: (connordp): If --dump-* is passed; logic!
+
     targetFile = shouldDumpJSON
     if targetFile:
         with open(targetFile, 'w') as fd:

--- a/objection/commands/ios/hooking.py
+++ b/objection/commands/ios/hooking.py
@@ -1,5 +1,5 @@
-from typing import Optional
 import json
+from typing import Optional
 
 import click
 
@@ -154,9 +154,7 @@ def show_ios_classes(args: list = None) -> None:
 
     # loop the class names and check if we should be ignoring it.
     for class_name in sorted(classes):
-
         if _should_ignore_native_classes(args):
-
             if not _class_is_prefixed_with_native(class_name):
                 click.secho(class_name)
                 continue
@@ -196,48 +194,20 @@ def show_ios_class_methods(args: list) -> None:
         click.secho('No class / methods found')
 
 
-def watch_class(args: list) -> None:
-    """
-        Starts an objection job that hooks into all of the methods
-        available in a class and reports on invocations.
-
-        :param args:
-        :return:
-    """
-
+def watch(args: list) -> None:
     if len(clean_argument_flags(args)) <= 0:
         click.secho('Usage: ios hooking watch class <class_name> (--include-parents)', bold=True)
         return
 
-    class_name = args[0]
+    should_watch_args = _should_dump_args(args)
+    should_watch_ret = _should_dump_return_value(args)
+    should_backtrace = _should_dump_backtrace(args)
+    should_watch_parents = _should_include_parent_methods(args)
+
+    pattern = args[0]
 
     api = state_connection.get_api()
-    api.ios_hooking_watch_class(class_name)
-
-
-def watch_class_method(args: list) -> None:
-    """
-        Starts an objection jon that hooks into a specific class method
-        and reports on invocations.
-
-        :param args:
-        :return:
-    """
-
-    if len(clean_argument_flags(args)) <= 0:
-        click.secho(('Usage: ios hooking watch method <selector> (eg: -[ClassName methodName:]) '
-                     '(optional: --dump-backtrace) '
-                     '(optional: --dump-args) '
-                     '(optional: --dump-return)'), bold=True)
-        return
-
-    selector = args[0]
-
-    api = state_connection.get_api()
-    api.ios_hooking_watch_method(selector,
-                                 _should_dump_args(args),
-                                 _should_dump_backtrace(args),
-                                 _should_dump_return_value(args))
+    api.ios_hooking_watch(pattern, should_watch_args, should_backtrace, should_watch_ret, should_watch_parents)
 
 
 def set_method_return_value(args: list) -> None:
@@ -274,10 +244,10 @@ def search_class(args: list) -> None:
         click.secho('Usage: ios hooking search classes <name>', bold=True)
         return
 
-    search = args[0]
+    query = args[0]
 
     api = state_connection.get_api()
-    classes = api.ios_hooking_get_classes(search)
+    classes = api.ios_hooking_get_classes(query)
     found_classes = 0
 
     if len(classes) > 0:
@@ -285,7 +255,7 @@ def search_class(args: list) -> None:
         # filter the classes for the search
         for classname in classes:
 
-            if search.lower() in classname.lower():
+            if query.lower() in classname.lower():
                 click.secho(classname)
                 found_classes += 1
 
@@ -307,10 +277,10 @@ def search_method(args: list) -> None:
         click.secho('Usage: ios hooking search methods <name>', bold=True)
         return
 
-    search = args[0]
+    query = args[0]
 
     api = state_connection.get_api()
-    methods = api.ios_hooking_search_methods(search)
+    methods = api.ios_hooking_search_methods(query)
 
     if len(methods) > 0:
 
@@ -324,83 +294,70 @@ def search_method(args: list) -> None:
         click.secho('No methods found')
 
 
-def enumerate(args: list) -> None:
+def search(args: list) -> None:
     """
-        Enumerates the current Android application for classes and methods.
+        Searches the current iOS application for classes and methods.
 
-        :param query:
+        :param args:
         :return:
     """
     if len(clean_argument_flags(args)) <= 0:
-        click.secho('Usage: ios hooking enumerate \'*[CLASS METHOD]\'', bold=True)
+        click.secho('Usage: ios hooking search \'*[CLASS METHOD]\'', bold=True)
         return
 
-    shouldPrintOnlyClasses = _should_print_only_classes(args)
-    shouldDumpJSON = _should_dump_json(args)
-    shouldWatchArgs = _should_dump_args(args)
-    shouldWatchRet = _should_dump_return_value(args)
-    shouldBeQuiet = _should_be_quiet(args)
-    shouldBacktrace = _should_dump_backtrace(args)
+    should_print_only_classes = _should_print_only_classes(args)
+    should_dump_json = _should_dump_json(args)
 
     api = state_connection.get_api()
-    results = api.ios_hooking_enumerate(args[0])
+    results = api.ios_hooking_search(args[0])
 
-    # Change the JSON we get into a form that matches the Android enumerate call
     data = {}
     for func in results:
         fullname = func['name']
-        startBracket = fullname.find('[') + 1
-        className = fullname[startBracket: fullname.find(' ')]
-        if data.get(className) is not None:
-            data[className].append(fullname)
+        start_bracket = fullname.find('[') + 1
+        class_name = fullname[start_bracket: fullname.find(' ')]
+        if data.get(class_name) is not None:
+            data[class_name].append(fullname)
         else:
-            data[className] = []
+            data[class_name] = []
 
     # Print the matching methods
     for klass in data.keys():
         methods = data[klass]
-        if not shouldBeQuiet:
-            print(klass)
+        print(klass)
         for method in methods:
-            if not shouldBeQuiet and not shouldPrintOnlyClasses:
+            if not should_print_only_classes:
                 print(f'\t{method}')
-            if shouldBacktrace or shouldWatchRet or shouldWatchArgs:
-                selector = method
-                api.ios_hooking_watch_method(selector,
-                                             _should_dump_args(args),
-                                             _should_dump_backtrace(args),
-                                             _should_dump_return_value(args))
 
-    # TODO: (connordp): If --dump-* is passed; logic!
-
-    targetFile = shouldDumpJSON
-    if targetFile:
-        with open(targetFile, 'w') as fd:
-            fd.write(json.dumps(data))
-            click.secho(f'JSON dumped to {shouldDumpJSON}', bold=True)
-
+    if should_dump_json:
+        target_file = _get_flag_value('--json', args)
+        if target_file:
+            with open(target_file, 'w') as fd:
+                fd.write(json.dumps(data))
+                click.secho(f'JSON dumped to {target_file}', bold=True)
 
 
 def _should_print_only_classes(args: list) -> bool:
-   return '--only-classes' in args
+    return '--only-classes' in args
 
 
+def _should_dump_json(args: list) -> bool:
+    return '--json' in args
 
-def _should_dump_json(args: list) -> Optional[str]:
+
+def _get_flag_value(flag:str, args: list) -> Optional[str]:
     target = None
     for i in range(len(args)):
-        if args[i] == '--json':
+        if args[i] == flag:
             target = i + 1
-        i = i + 1
 
     if target is None:
         return None
     elif target < len(args):
         return args[target]
     else:
-        click.secho('Please specify a target file', bold=True)
-
-    return None
+        click.secho(f'Could not find specified value for {flag}', bold=True)
+        return None
 
 
 def _should_be_quiet(args: list) -> bool:

--- a/objection/commands/ios/hooking.py
+++ b/objection/commands/ios/hooking.py
@@ -333,7 +333,12 @@ def search(args: list) -> None:
         target_file = _get_flag_value('--json', args)
         if target_file:
             with open(target_file, 'w') as fd:
-                fd.write(json.dumps(data))
+                fd.write(json.dumps({
+                    'meta': {
+                        'runtime': 'objc'
+                    },
+                    'classes': data
+                }))
                 click.secho(f'JSON dumped to {target_file}', bold=True)
 
 

--- a/objection/commands/native/search.py
+++ b/objection/commands/native/search.py
@@ -1,0 +1,60 @@
+import json
+from typing import Optional
+
+import click
+
+from objection.state.connection import state_connection
+from objection.utils.helpers import clean_argument_flags
+
+
+def _should_dump_json(args: list) -> bool:
+    return '--json' in args
+
+
+def _get_flag_value(flag: str, args: list) -> Optional[str]:
+    target = None
+    for i in range(len(args)):
+        if args[i] == flag:
+            target = i + 1
+
+    if target is None:
+        return None
+    elif target < len(args):
+        return args[target]
+    else:
+        click.secho(f'Could not find specified value for {flag}', bold=True)
+        return None
+
+
+def _should_be_quiet(args: list) -> bool:
+    return '--quiet' in args
+
+
+def search(args: list) -> None:
+    if len(clean_argument_flags(args)) < 1:
+        click.secho('Usage: native search <pattern> '
+                    '(eg: "exports:*!open")'
+                    '(optional: --json $target) '
+                    '(optional: --quiet) ',
+                    bold=True)
+    api = state_connection.get_api()
+    results = api.native_search(args[0])
+    results_json = {
+        'meta': {
+            'runtime': 'java'
+        },
+        'data': results
+    }
+
+    should_dump_json = _should_dump_json(args)
+    should_be_quiet = _should_be_quiet(args)
+    if should_dump_json:
+        target_file = _get_flag_value('--json', args)
+        with open(target_file, 'w') as fd:
+            fd.write(json.dumps(results_json))
+            click.secho(f'JSON dumped to {target_file}', bold=True)
+
+    if not should_be_quiet:
+        for entry in results:
+            print(entry['name'])
+    return

--- a/objection/console/commands.py
+++ b/objection/console/commands.py
@@ -383,7 +383,7 @@ COMMANDS = {
                     'enumerate': {
                         'meta': 'Enumerate Java classes and methods',
                         'exec': android_hooking.enumerate,
-                        'flags': ['--quiet', '--json', '--only-classes']
+                        'flags': ['--quiet', '--json', '--only-classes', '--dump-args', '--dump-return', '--dump-backtrace']
                     }
                 },
             },
@@ -737,7 +737,7 @@ COMMANDS = {
                     'enumerate': {
                         'meta': 'Enumerate ObjC classes and methods',
                         'exec': ios_hooking.enumerate,
-                        'flags': ['--quiet', '--json', '--only-classes']
+                        'flags': ['--quiet', '--json', '--only-classes', '--dump-args', '--dump-return', '--dump-backtrace']
                     }
                 }
             },

--- a/objection/console/commands.py
+++ b/objection/console/commands.py
@@ -323,7 +323,8 @@ COMMANDS = {
                     },
                     'watch': {
                         'meta': 'Watch for Android Java invocations',
-                        'exec': android_hooking.watch
+                        'exec': android_hooking.watch,
+                        'flags': ['--dump-args', '--dump-backtrace', '--dump-return']
                     },
                     'set': {
                         'meta': 'Set various values',
@@ -663,18 +664,8 @@ COMMANDS = {
                     },
                     'watch': {
                         'meta': 'Watch invocations of classes and methods',
-                        'commands': {
-                            'class': {
-                                'meta': 'Hook all methods in a class and report on invocations',
-                                'flags': ['--include-parents'],
-                                'exec': ios_hooking.watch_class
-                            },
-                            'method': {
-                                'meta': 'Hook a specific method and report on invocations',
-                                'flags': ['--dump-args', '--dump-backtrace', '--dump-return'],
-                                'exec': ios_hooking.watch_class_method
-                            }
-                        }
+                        'exec': ios_hooking.watch,
+                        'flags': ['--dump-args', '--dump-backtrace', '--dump-return'],
                     },
                     'set': {
                         'meta': 'Set various values',
@@ -687,16 +678,8 @@ COMMANDS = {
                     },
                     'search': {
                         'meta': 'Search for various classes and or methods',
-                        'commands': {
-                            'classes': {
-                                'meta': 'Search for Objective-C classes matching a name',
-                                'exec': ios_hooking.search_class
-                            },
-                            'methods': {
-                                'meta': 'Search for Objective-C method matching a name',
-                                'exec': ios_hooking.search_method
-                            }
-                        }
+                        'exec': ios_hooking.search,
+                        'flags': ['--json', '--only-classes', '--quiet']
                     },
                     'generate': {
                         'meta': 'Generate Frida hooks for iOS',
@@ -710,11 +693,6 @@ COMMANDS = {
                                 'exec': ios_generate.simple
                             }
                         },
-                },
-                    'enumerate': {
-                        'meta': 'Enumerate ObjC classes and methods',
-                        'exec': ios_hooking.enumerate,
-                        'flags': ['--quiet', '--json', '--only-classes', '--dump-args', '--dump-return', '--dump-backtrace']
                     }
                 }
             },

--- a/objection/console/commands.py
+++ b/objection/console/commands.py
@@ -732,7 +732,12 @@ COMMANDS = {
                                 'meta': 'Simple hooks for each Class method',
                                 'exec': ios_generate.simple
                             }
-                        }
+                        },
+                },
+                    'enumerate': {
+                        'meta': 'Enumerate ObjC classes and methods',
+                        'exec': ios_hooking.enumerate,
+                        'flags': ['--quiet', '--json', '--only-classes']
                     }
                 }
             },

--- a/objection/console/commands.py
+++ b/objection/console/commands.py
@@ -383,7 +383,7 @@ COMMANDS = {
                     'enumerate': {
                         'meta': 'Enumerate Java classes and methods',
                         'exec': android_hooking.enumerate,
-                        'flags': ['--quiet', '--json']
+                        'flags': ['--quiet', '--json', '--only-classes']
                     }
                 },
             },

--- a/objection/console/commands.py
+++ b/objection/console/commands.py
@@ -350,6 +350,10 @@ COMMANDS = {
                         'exec': android_hooking.search,
                         'flags': ['--json', '--only-classes', '--quiet']
                     },
+                    'notify': {
+                        'meta': 'TODO',
+                        'exec': android_hooking.notify
+                    },
                     'generate': {
                         'meta': 'Generate Frida hooks for Android',
                         'commands': {

--- a/objection/console/commands.py
+++ b/objection/console/commands.py
@@ -9,6 +9,7 @@ from ..commands import memory
 from ..commands import plugin_manager
 from ..commands import sqlite
 from ..commands import ui
+from ..commands.native import search as native_search
 from ..commands.android import clipboard
 from ..commands.android import command
 from ..commands.android import general
@@ -272,6 +273,18 @@ COMMANDS = {
             'alert': {
                 'meta': 'Show an alert message, optionally specifying the message to show. (Currently crashes iOS)',
                 'exec': ui.alert
+            }
+        }
+    },
+
+    # native commands
+
+    'native': {
+        'meta': 'Commands specific to native modules',
+        'commands': {
+            'search': {
+                'meta': 'Search for native modules',
+                'exec': native_search.search
             }
         }
     },

--- a/objection/console/commands.py
+++ b/objection/console/commands.py
@@ -323,25 +323,15 @@ COMMANDS = {
                     },
                     'watch': {
                         'meta': 'Watch for Android Java invocations',
-                        'commands': {
-                            'class': {
-                                'meta': 'Watches for invocations of all methods in a class',
-                                'flags': ['--dump-args', '--dump-backtrace', '--dump-return'],
-                                'exec': android_hooking.watch_class,
-                            },
-                            'class_method': {
-                                'meta': 'Watches for invocations of a specific class method',
-                                'flags': ['--dump-args', '--dump-backtrace', '--dump-return'],
-                                'exec': android_hooking.watch_class_method
-                            }
-                        }
+                        'exec': android_hooking.watch
                     },
                     'set': {
                         'meta': 'Set various values',
                         'commands': {
                             'return_value': {
                                 'meta': 'Set a methods return value. Supports only boolean returns.',
-                                'exec': android_hooking.set_method_return_value
+                                'exec': android_hooking.set_method_return_value,
+                                'flags': ['--dump-args', '--dump-return', '--dump-backtrace']
                             }
                         }
                     },

--- a/objection/console/commands.py
+++ b/objection/console/commands.py
@@ -379,6 +379,11 @@ COMMANDS = {
                                 'exec': android_generate.simple
                             }
                         }
+                    },
+                    'enumerate': {
+                        'meta': 'Enumerate Java classes and methods',
+                        'exec': android_hooking.enumerate,
+                        'flags': ['--quiet', '--json']
                     }
                 },
             },

--- a/objection/console/commands.py
+++ b/objection/console/commands.py
@@ -346,16 +346,8 @@ COMMANDS = {
                     },
                     'search': {
                         'meta': 'Search for various classes and or methods',
-                        'commands': {
-                            'classes': {
-                                'meta': 'Search for Java classes matching a name',
-                                'exec': android_hooking.search_class
-                            },
-                            'methods': {
-                                'meta': 'Search for Java methods matching a name',
-                                'exec': android_hooking.search_methods
-                            }
-                        }
+                        'exec': android_hooking.search,
+                        'flags': ['--json', '--only-classes', '--quiet']
                     },
                     'generate': {
                         'meta': 'Generate Frida hooks for Android',
@@ -369,11 +361,6 @@ COMMANDS = {
                                 'exec': android_generate.simple
                             }
                         }
-                    },
-                    'enumerate': {
-                        'meta': 'Enumerate Java classes and methods',
-                        'exec': android_hooking.enumerate,
-                        'flags': ['--quiet', '--json', '--only-classes', '--dump-args', '--dump-return', '--dump-backtrace']
                     }
                 },
             },

--- a/objection/utils/assets/javahookmanager.js
+++ b/objection/utils/assets/javahookmanager.js
@@ -87,7 +87,7 @@ class JavaHookManager {
       return;
     }
 
-    this.printVerbose(`Hookig ${m} and all overloads...`);
+    this.printVerbose(`Hooking ${m} and all overloads...`);
 
     var r = [];
     this.target[m].overloads.forEach(overload => {

--- a/objection/utils/assets/objchookmanager.js
+++ b/objection/utils/assets/objchookmanager.js
@@ -65,7 +65,7 @@ class ObjCHookManager {
       return;
     }
 
-    this.printVerbose(`Hookig ${m}...`);
+    this.printVerbose(`Hooking ${m}...`);
 
     const l = Interceptor.attach(this.target[m].implementation, {
       onEnter: function (args) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "objection",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {}
+}


### PR DESCRIPTION
Hi I'm opening this a bit earlier to get some feedback.  The idea behind this is to expose `Java.enumerateMethods()` to the Objection agent.  This can be used in the REPL via `android hooking enumerate $pattern`. It supports two flags `--json` and `--quiet`

I'm not sure if I need to do some more work to add this to the API or not? 

Any feedback is welcome :) Thanks @egeldenhuys for pointing out my typos.