### PR TITLE
Fix mem dump

### DIFF
--- a/agent/src/generic/memory.ts
+++ b/agent/src/generic/memory.ts
@@ -18,10 +18,11 @@ export namespace memory {
     return Process.enumerateRanges(protection);
   };
 
-  export const dump = (address: string, size: number): ArrayBuffer => {
+  export const dump = (address: string, size: number): Uint8Array => {
     // Originally part of Frida <=11 but got removed in 12.
     // https://github.com/frida/frida-python/commit/72899a4315998289fb171149d62477ba7d1fcb91
-    return new NativePointer(address).readByteArray(size);
+    const buffer = new NativePointer(address).readByteArray(size);
+    return new Uint8Array(buffer);
   };
 
   export const search = (pattern: string, onlyOffsets: boolean = false): string[] => {

--- a/agent/src/generic/memory.ts
+++ b/agent/src/generic/memory.ts
@@ -18,11 +18,10 @@ export namespace memory {
     return Process.enumerateRanges(protection);
   };
 
-  export const dump = (address: string, size: number): Uint8Array => {
+  export const dump = (address: string, size: number): ArrayBuffer => {
     // Originally part of Frida <=11 but got removed in 12.
     // https://github.com/frida/frida-python/commit/72899a4315998289fb171149d62477ba7d1fcb91
-    const buffer = new NativePointer(address).readByteArray(size);
-    return new Uint8Array(buffer);
+    return new NativePointer(address).readByteArray(size);
   };
 
   export const search = (pattern: string, onlyOffsets: boolean = false): string[] => {

--- a/objection/commands/memory.py
+++ b/objection/commands/memory.py
@@ -1,5 +1,8 @@
 import json
 import os
+import math
+
+from typing import List
 
 import click
 from tabulate import tabulate
@@ -8,6 +11,7 @@ from objection.state.connection import state_connection
 from ..utils.helpers import clean_argument_flags
 from ..utils.helpers import sizeof_fmt, pretty_concat
 
+BLOCK_SIZE = 4096 * 100
 
 def _is_string_input(args: list) -> bool:
     """
@@ -91,7 +95,11 @@ def dump_all(args: list) -> None:
             # changes or the range is reallocated
             try:
                 # grab the (size) bytes starting at the (base_address)
-                dump = api.memory_dump(int(image['base'], 16), image['size'])
+                chunks = _get_chunks(int(image['base'], 16), int(image['size']), BLOCK_SIZE)
+                for chunk in chunks:
+                    # Print some output...
+                    # click.secho(f'\t\t Dumping chunk {chunk[0]}...', fg='green', bold=True)
+                    dump = bytearray(api.memory_dump(chunk[0], chunk[1]))
             except Exception:
                 continue
 
@@ -101,6 +109,21 @@ def dump_all(args: list) -> None:
 
     click.secho('Memory dumped to file: {0}'.format(destination), fg='green')
 
+
+def _get_chunks(addr: int, size: int, block_size: int) -> List:
+  if size > BLOCK_SIZE:
+    block_count = size // BLOCK_SIZE
+    extra_block = size % BLOCK_SIZE
+    ranges = []
+    current_address = addr
+    for i in range(block_count):
+      ranges.append((current_address, BLOCK_SIZE))
+      current_address += BLOCK_SIZE
+    if extra_block != 0:
+      ranges.append((current_address, extra_block))
+    return ranges
+  else:
+    return [(addr, size)]
 
 def dump_from_base(args: list) -> None:
     """
@@ -129,7 +152,15 @@ def dump_from_base(args: list) -> None:
                 fg='green', dim=True)
 
     api = state_connection.get_api()
-    dump = api.memory_dump(int(base_address, 16), int(memory_size))
+
+    # iirc, if you don't cast the return type to a bytearray it uses the sizeof(int) per cell, which is massive
+    dump = bytearray()
+    chunks = _get_chunks(int(base_address, 16), int(memory_size), BLOCK_SIZE)
+    for chunk in chunks:
+        # Print some output...
+        click.secho(f'\t\t Dumping chunk {chunk[0]}...', fg='green', bold=True)
+        dump.extend(bytearray(api.memory_dump(chunk[0], chunk[1])))
+
 
     # append the results to the destination file
     with open(destination, 'wb') as f:

--- a/objection/commands/memory.py
+++ b/objection/commands/memory.py
@@ -11,7 +11,7 @@ from objection.state.connection import state_connection
 from ..utils.helpers import clean_argument_flags
 from ..utils.helpers import sizeof_fmt, pretty_concat
 
-BLOCK_SIZE = 4096 * 100
+BLOCK_SIZE = 40960000
 
 def _is_string_input(args: list) -> bool:
     """
@@ -88,8 +88,9 @@ def dump_all(args: list) -> None:
 
     with click.progressbar(ranges) as bar:
         for image in bar:
+            dump = bytearray()
             bar.label = 'Dumping {0} from base: {1}'.format(sizeof_fmt(image['size']), hex(int(image['base'], 16)))
-
+        
             # catch and exception thrown while dumping.
             # this could for a few reasons like if the protection
             # changes or the range is reallocated
@@ -97,10 +98,9 @@ def dump_all(args: list) -> None:
                 # grab the (size) bytes starting at the (base_address)
                 chunks = _get_chunks(int(image['base'], 16), int(image['size']), BLOCK_SIZE)
                 for chunk in chunks:
-                    # Print some output...
-                    # click.secho(f'\t\t Dumping chunk {chunk[0]}...', fg='green', bold=True)
-                    dump = bytearray(api.memory_dump(chunk[0], chunk[1]))
-            except Exception:
+                    dump.extend(api.memory_dump(chunk[0], chunk[1]))
+                    
+            except Exception as e:
                 continue
 
             # append the results to the destination file
@@ -157,8 +157,6 @@ def dump_from_base(args: list) -> None:
     dump = bytearray()
     chunks = _get_chunks(int(base_address, 16), int(memory_size), BLOCK_SIZE)
     for chunk in chunks:
-        # Print some output...
-        click.secho(f'\t\t Dumping chunk {chunk[0]}...', fg='green', bold=True)
         dump.extend(bytearray(api.memory_dump(chunk[0], chunk[1])))
 
 

--- a/objection/commands/memory.py
+++ b/objection/commands/memory.py
@@ -110,7 +110,7 @@ def dump_all(args: list) -> None:
     click.secho('Memory dumped to file: {0}'.format(destination), fg='green')
 
 
-def _get_chunks(addr: int, size: int, block_size: int) -> List:
+def _get_chunks(addr: int, size: int) -> List:
   if size > BLOCK_SIZE:
     block_count = size // BLOCK_SIZE
     extra_block = size % BLOCK_SIZE


### PR DESCRIPTION
This PR adds chunking to the memory dump functions. The core logic is here:

```python
def _get_chunks(addr: int, size: int) -> List:
  if size > BLOCK_SIZE:
    block_count = size // BLOCK_SIZE
    extra_block = size % BLOCK_SIZE
    ranges = []
    current_address = addr
    for i in range(block_count):
      ranges.append((current_address, BLOCK_SIZE))
      current_address += BLOCK_SIZE
    if extra_block != 0:
      ranges.append((current_address, extra_block))
    return ranges
  else:
    return [(addr, size)]
```