### PR TITLE
Added --uid flag

### DIFF
--- a/objection/console/cli.py
+++ b/objection/console/cli.py
@@ -17,7 +17,6 @@ from ..state.connection import state_connection
 
 def get_agent() -> Agent:
     """ get_agent bootstraps an agent instance """
-
     agent = Agent(AgentConfig(
         name=state_connection.name,
         host=state_connection.host,
@@ -27,7 +26,8 @@ def get_agent() -> Agent:
         spawn=state_connection.spawn,
         foremost=state_connection.foremost,
         debugger=state_connection.debugger,
-        pause=not state_connection.no_pause
+        pause=not state_connection.no_pause,
+        uid=state_connection.uid
     ))
 
     agent.run()
@@ -52,8 +52,10 @@ def get_agent() -> Agent:
 @click.option('--no-pause', '-p', required=False, is_flag=True, help='Resume the target immediately.')
 @click.option('--foremost', '-f', required=False, is_flag=True, help='Use the current foremost application.')
 @click.option('--debugger', required=False, default=False, is_flag=True, help='Enable the Chrome debug port.')
+@click.option('--uid', required=False, default=None, help='Specify the uid to run as (Android only).')
 def cli(network: bool, host: str, port: int, api_host: str, api_port: int,
-        name: str, serial: str, debug: bool, spawn: bool, no_pause: bool, foremost: bool, debugger: bool) -> None:
+        name: str, serial: str, debug: bool, spawn: bool, no_pause: bool, 
+        foremost: bool, debugger: bool, uid: int) -> None:
     """
         \b
              _   _         _   _
@@ -86,6 +88,7 @@ def cli(network: bool, host: str, port: int, api_host: str, api_port: int,
     state_connection.no_pause = no_pause
     state_connection.foremost = foremost
     state_connection.debugger = debugger
+    state_connection.uid = uid
 
 
 @cli.command()

--- a/objection/state/connection.py
+++ b/objection/state/connection.py
@@ -21,6 +21,7 @@ class StateConnection(object):
         self.name = None
         self.agent = None
         self.api = None
+        self.uid = None
 
     def use_usb(self) -> None:
         """

--- a/objection/utils/agent.py
+++ b/objection/utils/agent.py
@@ -29,6 +29,7 @@ class AgentConfig(object):
     spawn: bool = False
     pause: bool = True
     debugger: bool = False
+    uid: int = None
 
 
 class OutputHandlers(object):
@@ -212,9 +213,11 @@ class Agent(object):
             self.pid = app.pid
             # update the global state for the prompt etc.
             state_connection.name = app.identifier
-
         elif self.config.spawn:
-            self.pid = self.device.spawn(self.config.name)
+            if self.config.uid is not None:
+                self.pid = self.device.spawn(self.config.name, uid=int(self.config.uid))
+            else:
+                self.pid = self.device.spawn(self.config.name)
             self.resumed = False
         else:
             # check if the name is actually an integer. this way we can
@@ -239,8 +242,10 @@ class Agent(object):
 
         if self.pid is None:
             raise Exception('A PID needs to be set before attach()')
-
-        self.session = self.device.attach(self.pid)
+        if self.config.uid is None:
+            self.session = self.device.attach(self.pid)
+        else:
+            self.session = self.device.attach(self.pid, uid=self.config.uid)
         self.session.on('detached', self.handlers.session_on_detached)
 
         if self.config.debugger:


### PR DESCRIPTION
This PR adds a `--uid` flag that can be used to specify the user to run as, useful for situations where Android for work is involved. I don't have an Android for work environment setup so I've only tested whether or not this breaks if a non-existing uid is passed - would be very grateful if someone else has a moment to test this :) 