### PR TITLE
Bump frida

### DIFF
--- a/objection/utils/agent.py
+++ b/objection/utils/agent.py
@@ -251,10 +251,11 @@ class Agent(object):
 
         self.session.on('detached', self.handlers.session_on_detached)
 
-        if self.config.debugger:
-            self.session.enable_debugger()
 
         self.script = self.session.create_script(source=self._get_agent_source())
+        if self.config.debugger:
+            click.secho('Debugger enabled, visit chrome://inspect', bold=True)
+            self.script.enable_debugger()
         self.script.on('message', self.handlers.script_on_message)
         self.script.load()
 

--- a/objection/utils/agent.py
+++ b/objection/utils/agent.py
@@ -252,10 +252,15 @@ class Agent(object):
         self.session.on('detached', self.handlers.session_on_detached)
 
 
-        self.script = self.session.create_script(source=self._get_agent_source())
+        # Default runtime is qjs, however the chrome web debugger does not work with that
+        # TODO: Maybe at some point it'd be useful to have an option to select the runtime
         if self.config.debugger:
+            self.script = self.session.create_script(source=self._get_agent_source(), runtime='v8')
             click.secho('Debugger enabled, visit chrome://inspect', bold=True)
             self.script.enable_debugger()
+        else:
+            self.script = self.session.create_script(source=self._get_agent_source())
+
         self.script.on('message', self.handlers.script_on_message)
         self.script.load()
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,5 @@
-frida==16.0.2
-frida-tools==12.0.1
+frida>=16.0.2
+frida-tools>=12.0.1
 prompt_toolkit>=3.0.3,<4.0.0
 click
 tabulate

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,5 @@
-frida
-frida-tools>=6.0.0
+frida==16.0.2
+frida-tools==12.0.1
 prompt_toolkit>=3.0.3,<4.0.0
 click
 tabulate

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 frida>=16.0.2
-frida-tools==12.0.1
+frida-tools>=12.0.1
 prompt_toolkit>=3.0.3,<4.0.0
 click
 tabulate

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-frida>=15.0.0
-frida-tools>=10.0.0
+frida==16.0.2
+frida-tools==12.0.1
 prompt_toolkit>=3.0.3,<4.0.0
 click
 tabulate

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-frida==16.0.2
+frida>=16.0.2
 frida-tools==12.0.1
 prompt_toolkit>=3.0.3,<4.0.0
 click


### PR DESCRIPTION
I changed the frida version to 16.0.2 and the frida-tools version to 12.0.1

The only thing that needed to change for frida was that enable_debugger has moved to the script object. At the same time, I think if you want to use this functionality the runtime has to be v8 -- since I vaguely recall reading that somewhere and that it doesn't work if the runtime isn't v8. 

I'm not sure if upgrading frida-tools needed any changes as everything still worked for me :) 