### PR TITLE
Added --watch and friends to notify

### DIFF
--- a/agent/src/rpc/android.ts
+++ b/agent/src/rpc/android.ts
@@ -58,7 +58,7 @@ export const android = {
   androidHookingWatch: (pattern: string, watchArgs: boolean, watchBacktrace: boolean, watchRet: boolean): Promise<void> =>
     hooking.watch(pattern, watchArgs, watchBacktrace, watchRet),
   androidHookingEnumerate: (query: string): Promise<Java.EnumerateMethodsMatchGroup[]> => hooking.javaEnumerate(query),
-  androidHookingLazyWatchForPattern: (query: string): void => hooking.lazyWatchForPattern(query),
+  androidHookingLazyWatchForPattern: (query: string, watch: boolean, dargs: boolean, dret: boolean, dbt: boolean): void => hooking.lazyWatchForPattern(query, watch, dargs, dret, dbt),
 
   // android heap methods
   androidHeapEvaluateHandleMethod: (handle: number, js: string): Promise<void> => heap.evaluate(handle, js),

--- a/objection/commands/android/hooking.py
+++ b/objection/commands/android/hooking.py
@@ -51,6 +51,17 @@ def _should_dump_backtrace(args: list = None) -> bool:
     return '--dump-backtrace' in args
 
 
+def _should_watch(args: list = None) -> bool:
+    """
+        Check if --dump-args is part of the arguments.
+
+        :param args:
+        :return:
+    """
+
+    return '--watch' in args
+
+
 def _should_dump_args(args: list = None) -> bool:
     """
         Check if --dump-args is part of the arguments.
@@ -207,7 +218,14 @@ def notify(args: list = None) -> None:
         return
 
     api = state_connection.get_api()
-    api.android_hooking_lazy_watch_for_pattern(query)
+    should_watch = _should_watch(args)
+    dump_arguments = _should_dump_args(args)
+    dump_backtrace = _should_dump_backtrace(args)
+    dump_return = _should_dump_return_value(args)
+    api.android_hooking_lazy_watch_for_pattern(query, 
+        should_watch, dump_arguments, 
+        dump_return, 
+        dump_backtrace)
 
 
 def watch(args: list = None) -> None:

--- a/objection/console/commands.py
+++ b/objection/console/commands.py
@@ -352,7 +352,9 @@ COMMANDS = {
                     },
                     'notify': {
                         'meta': 'Notify when a class becomes available',
-                        'exec': android_hooking.notify
+                        'exec': android_hooking.notify,
+                        'flags': ['--dump-args', '--dump-return', '--dump-backtrace', '--watch']
+
                     },
                     'generate': {
                         'meta': 'Generate Frida hooks for Android',


### PR DESCRIPTION
Basically this adds the ability to specify `--watch --dump-*` which will when the class is loaded (lazy check), also invoke the same function that `android hooking watch` does. 

This is useful if you want to observe what an injected class does, since you no longer have to manually run watch once you know it's loaded. 

