### PR TITLE
Few enhancements to gadget injection into APK (patchapk)

### DIFF
--- a/objection/commands/mobile_packages.py
+++ b/objection/commands/mobile_packages.py
@@ -99,7 +99,8 @@ def patch_ios_ipa(source: str, codesign_signature: str, provision_file: str, bin
 def patch_android_apk(source: str, architecture: str, pause: bool, skip_cleanup: bool = True,
                       enable_debug: bool = True, gadget_version: str = None, skip_resources: bool = False,
                       network_security_config: bool = False, target_class: str = None,
-                      use_aapt2: bool = False, gadget_config: str = None, script_source: str = None,
+                      use_aapt2: bool = False, gadget_name: str = 'libfrida-gadget.so',
+                      gadget_config: str = None, script_source: str = None,
                       ignore_nativelibs: bool = False, manifest: str = None) -> None:
     """
         Patches an Android APK by extracting, patching SMALI, repackaging
@@ -115,6 +116,7 @@ def patch_android_apk(source: str, architecture: str, pause: bool, skip_cleanup:
         :param network_security_config:
         :param target_class:
         :param use_aapt2:
+        :param gadget_name:
         :param gadget_config:
         :param script_source:
         :param manifest:
@@ -199,8 +201,12 @@ def patch_android_apk(source: str, architecture: str, pause: bool, skip_cleanup:
     if network_security_config:
         patcher.add_network_security_config()
 
+    patcher.add_gadget_to_apk(
+        architecture,
+        android_gadget.get_frida_library_path(), gadget_config,
+        gadget_name
+    )
     patcher.inject_load_library(target_class=target_class)
-    patcher.add_gadget_to_apk(architecture, android_gadget.get_frida_library_path(), gadget_config)
 
     if script_source:
         click.secho('Copying over a custom script to use with the gadget config.', fg='green')

--- a/objection/commands/mobile_packages.py
+++ b/objection/commands/mobile_packages.py
@@ -100,7 +100,7 @@ def patch_android_apk(source: str, architecture: str, pause: bool, skip_cleanup:
                       enable_debug: bool = True, gadget_version: str = None, skip_resources: bool = False,
                       network_security_config: bool = False, target_class: str = None,
                       use_aapt2: bool = False, gadget_config: str = None, script_source: str = None,
-                      ignore_nativelibs: bool = True, manifest: str = None) -> None:
+                      ignore_nativelibs: bool = False, manifest: str = None) -> None:
     """
         Patches an Android APK by extracting, patching SMALI, repackaging
         and signing a new APK.
@@ -121,7 +121,6 @@ def patch_android_apk(source: str, architecture: str, pause: bool, skip_cleanup:
 
         :return:
     """
-
     github = Github(gadget_version=gadget_version)
     android_gadget = AndroidGadget(github)
 

--- a/objection/commands/mobile_packages.py
+++ b/objection/commands/mobile_packages.py
@@ -99,7 +99,7 @@ def patch_ios_ipa(source: str, codesign_signature: str, provision_file: str, bin
 def patch_android_apk(source: str, architecture: str, pause: bool, skip_cleanup: bool = True,
                       enable_debug: bool = True, gadget_version: str = None, skip_resources: bool = False,
                       network_security_config: bool = False, target_class: str = None,
-                      use_aapt2: bool = False, gadget_name: str = 'libfrida-gadget.so',
+                      use_aapt2: bool = True, gadget_name: str = 'libfrida-gadget.so',
                       gadget_config: str = None, script_source: str = None,
                       ignore_nativelibs: bool = False, manifest: str = None) -> None:
     """

--- a/objection/console/cli.py
+++ b/objection/console/cli.py
@@ -268,6 +268,12 @@ def patchipa(source: str, gadget_version: str, codesign_signature: str, provisio
 @click.option('--target-class', '-t', help='The target class to patch.', default=None)
 @click.option('--use-aapt2', '-2', is_flag=True, default=False,
               help='Use the aapt2 binary instead of aapt as part of the apktool processing.', show_default=True)
+@click.option('--gadget-name', '-g', default='libfrida-gadget.so',
+              help=(
+                  'Name of the gadget library. Can be named whatever you want to dodge anti-frida '
+                  'detection schemes looking for loaded libraries with frida in the name.'
+                  'Refer to https://frida.re/docs/gadget/ for more information.'),
+              show_default=True)
 @click.option('--gadget-config', '-c', default=None, help=(
         'The gadget configuration file to use. '
         'Refer to https://frida.re/docs/gadget/ for more information.'), show_default=False)
@@ -279,7 +285,7 @@ def patchipa(source: str, gadget_version: str, codesign_signature: str, provisio
 @click.option('--manifest', '-m', help='A decoded AndroidManifest.xml file to read.', default=None)
 def patchapk(source: str, architecture: str, gadget_version: str, pause: bool, skip_cleanup: bool,
              enable_debug: bool, skip_resources: bool, network_security_config: bool, target_class: str,
-             use_aapt2: bool, gadget_config: str, script_source: str, ignore_nativelibs: bool, manifest: str) -> None:
+             use_aapt2: bool, gadget_name: str, gadget_config: str, script_source: str, ignore_nativelibs: bool, manifest: str) -> None:
     """
         Patch an APK with the frida-gadget.so.
     """
@@ -297,6 +303,11 @@ def patchapk(source: str, architecture: str, gadget_version: str, pause: bool, s
     # ensure we decode resources if we do not have the --ignore-nativelibs flag.
     if not ignore_nativelibs and skip_resources:
         click.secho('The --ignore-nativelibs flag is required with the --skip-resources flag.', fg='red')
+        return
+
+    # ensure provided gadget name is a valid android lib name
+    if not gadget_name.startswith('lib') or not gadget_name.endswith('.so'):
+        click.secho("Gadget name should start with 'lib' and end in '.so'", fg='red')
         return
 
     patch_android_apk(**locals())

--- a/objection/console/cli.py
+++ b/objection/console/cli.py
@@ -266,8 +266,8 @@ def patchipa(source: str, gadget_version: str, codesign_signature: str, provisio
 @click.option('--skip-resources', '-D', is_flag=True, default=False,
               help='Skip resource decoding as part of the apktool processing.', show_default=True)
 @click.option('--target-class', '-t', help='The target class to patch.', default=None)
-@click.option('--use-aapt2', '-2', is_flag=True, default=False,
-              help='Use the aapt2 binary instead of aapt as part of the apktool processing.', show_default=True)
+@click.option('--use-aapt2', '-2', is_flag=True, default=True,
+              help='Use the aapt2 binary instead of aapt au part of the apktool processing.', show_default=True)
 @click.option('--gadget-name', '-g', default='libfrida-gadget.so',
               help=(
                   'Name of the gadget library. Can be named whatever you want to dodge anti-frida '

--- a/objection/console/cli.py
+++ b/objection/console/cli.py
@@ -54,7 +54,7 @@ def get_agent() -> Agent:
 @click.option('--debugger', required=False, default=False, is_flag=True, help='Enable the Chrome debug port.')
 @click.option('--uid', required=False, default=None, help='Specify the uid to run as (Android only).')
 def cli(network: bool, host: str, port: int, api_host: str, api_port: int,
-        name: str, serial: str, debug: bool, spawn: bool, no_pause: bool, 
+        name: str, serial: str, debug: bool, spawn: bool, no_pause: bool,
         foremost: bool, debugger: bool, uid: int) -> None:
     """
         \b
@@ -255,18 +255,19 @@ def patchipa(source: str, gadget_version: str, codesign_signature: str, provisio
                                               'specified, the latest version will be used.'), default=None)
 @click.option('--pause', '-p', is_flag=True, help='Pause the patcher before rebuilding the APK.',
               show_default=True)
-@click.option('--skip-cleanup', '-k', is_flag=True,
+@click.option('--skip-cleanup', '-k', is_flag=True, default=True,
               help='Do not clean temporary files once finished.', show_default=True)
-@click.option('--enable-debug', '-d', is_flag=True,
+@click.option('--enable-debug', '-d', is_flag=True, default=True,
               help='Set the android:debuggable flag to true in the application manifest.', show_default=True)
 @click.option('--network-security-config', '-N', is_flag=True, default=False,
               help='Include a network_security_config.xml file allowing for user added CA\'s to be trusted on '
-                   'Android 7 and up. This option can not be used with the --skip-resources flag.')
+                   'Android 7 and up. This option can not be used with the --skip-resources flag.',
+              show_default=True)
 @click.option('--skip-resources', '-D', is_flag=True, default=False,
-              help='Skip resource decoding as part of the apktool processing.', show_default=False)
+              help='Skip resource decoding as part of the apktool processing.', show_default=True)
 @click.option('--target-class', '-t', help='The target class to patch.', default=None)
 @click.option('--use-aapt2', '-2', is_flag=True, default=False,
-              help='Use the aapt2 binary instead of aapt as part of the apktool processing.', show_default=False)
+              help='Use the aapt2 binary instead of aapt as part of the apktool processing.', show_default=True)
 @click.option('--gadget-config', '-c', default=None, help=(
         'The gadget configuration file to use. '
         'Refer to https://frida.re/docs/gadget/ for more information.'), show_default=False)

--- a/objection/utils/patchers/android.py
+++ b/objection/utils/patchers/android.py
@@ -1,4 +1,5 @@
 import contextlib
+import functools
 import lzma
 import os
 import re
@@ -803,6 +804,30 @@ class AndroidPatcher(BasePlatformPatcher):
 
         return patched_smali
 
+    @functools.cache
+    def _find_libs_path(self):
+        """
+            Find the libraries path for the target architecture within the APK.
+        """
+        base_libs_path = os.path.join(self.apk_temp_directory, 'lib')
+        available_libs_arch = os.listdir(base_libs_path)
+        if self.architecture in available_libs_arch:
+            # Exact match with arch
+            return os.path.join(base_libs_path, self.architecture)
+        else:
+            # Try to use prefix search
+            try:
+                matching_arch = next(
+                    item for item in available_libs_arch if item.startswith(self.architecture)
+                )
+                click.secho('Using matching architecture {0} from provided architecture {1}.'.format(
+                    matching_arch, self.architecture
+                ), dim=True)
+                return os.path.join(base_libs_path, matching_arch)
+            except StopIteration:
+                # Might create the arch folder inside the APK tree
+                return os.path.join(base_libs_path, self.architecture)
+
     def inject_load_library(self, target_class: str = None):
         """
             Injects a loadLibrary call into a class.
@@ -828,7 +853,7 @@ class AndroidPatcher(BasePlatformPatcher):
             # Inspired by https://fadeevab.com/frida-gadget-injection-on-android-no-root-2-methods/
             if not self.architecture or not self.libfridagadget_name:
                 raise Exception('Frida-gadget should have been copied prior to injecting!')
-            libs_path = os.path.join(self.apk_temp_directory, 'lib', self.architecture)
+            libs_path = self._find_libs_path()
             existing_libs_in_apk = [
                 lib
                 for lib in os.listdir(libs_path)
@@ -889,7 +914,7 @@ class AndroidPatcher(BasePlatformPatcher):
         self.libfridagadget_name = libfridagadget_name
         self.libfridagadgetconfig_name = libfridagadget_name.replace('.so', '.config.so')
 
-        libs_path = os.path.join(self.apk_temp_directory, 'lib', architecture)
+        libs_path = self._find_libs_path()
 
         # check if the libs path exists
         if not os.path.exists(libs_path):

--- a/objection/utils/patchers/android.py
+++ b/objection/utils/patchers/android.py
@@ -8,6 +8,7 @@ import xml.etree.ElementTree as ElementTree
 
 import click
 import delegator
+import lief
 import requests
 import semver
 
@@ -210,6 +211,8 @@ class AndroidPatcher(BasePlatformPatcher):
         self.skip_cleanup = skip_cleanup
         self.skip_resources = skip_resources
         self.manifest = manifest
+
+        self.architecture = None
 
         self.keystore = os.path.join(os.path.abspath(os.path.dirname(__file__)), '../assets', 'objection.jks')
         self.netsec_config = os.path.join(os.path.abspath(os.path.dirname(__file__)), '../assets',
@@ -820,8 +823,26 @@ class AndroidPatcher(BasePlatformPatcher):
         if target_class:
             click.secho('Using target class: {0} for patch'.format(target_class), fg='green', bold=True)
         else:
-            click.secho('Target class not specified, searching for launchable activity instead...', fg='green',
+            click.secho('Target class not specified, injecting through existing native libraries...', fg='green',
                         bold=True)
+            # Inspired by https://fadeevab.com/frida-gadget-injection-on-android-no-root-2-methods/
+            if not self.architecture:
+                raise Exception('Frida-gadget should have been copied prior to injecting!')
+            libs_path = os.path.join(self.apk_temp_directory, 'lib', self.architecture)
+            existing_libs_in_apk = [
+                lib
+                for lib in os.listdir(libs_path)
+                if lib not in ['libfrida-gadget.so', self.libfridagadgetconfig_name]
+            ]
+            if existing_libs_in_apk:
+                for lib in existing_libs_in_apk:
+                    libnative = lief.parse(os.path.join(libs_path, lib))
+                    libnative.add_library('libfrida-gadget.so')  # Injection!
+                    libnative.write(os.path.join(libs_path, lib))
+                return
+            else:
+                click.secho('No native libraries found in APK, searching for launchable activity instead...', fg='green',
+                            bold=True)
 
         activity_path = self._determine_smali_path_for_class(
             target_class if target_class else self._get_launchable_activity())
@@ -861,6 +882,7 @@ class AndroidPatcher(BasePlatformPatcher):
             :param gadget_config:
             :return:
         """
+        self.architecture = architecture
 
         libs_path = os.path.join(self.apk_temp_directory, 'lib', architecture)
 

--- a/objection/utils/patchers/android.py
+++ b/objection/utils/patchers/android.py
@@ -826,18 +826,18 @@ class AndroidPatcher(BasePlatformPatcher):
             click.secho('Target class not specified, injecting through existing native libraries...', fg='green',
                         bold=True)
             # Inspired by https://fadeevab.com/frida-gadget-injection-on-android-no-root-2-methods/
-            if not self.architecture:
+            if not self.architecture or not self.libfridagadget_name:
                 raise Exception('Frida-gadget should have been copied prior to injecting!')
             libs_path = os.path.join(self.apk_temp_directory, 'lib', self.architecture)
             existing_libs_in_apk = [
                 lib
                 for lib in os.listdir(libs_path)
-                if lib not in ['libfrida-gadget.so', self.libfridagadgetconfig_name]
+                if lib not in [self.libfridagadget_name, self.libfridagadgetconfig_name]
             ]
             if existing_libs_in_apk:
                 for lib in existing_libs_in_apk:
                     libnative = lief.parse(os.path.join(libs_path, lib))
-                    libnative.add_library('libfrida-gadget.so')  # Injection!
+                    libnative.add_library(self.libfridagadget_name)  # Injection!
                     libnative.write(os.path.join(libs_path, lib))
                 return
             else:
@@ -872,7 +872,9 @@ class AndroidPatcher(BasePlatformPatcher):
         with open(activity_path, 'w') as f:
             f.write(''.join(patched_smali))
 
-    def add_gadget_to_apk(self, architecture: str, gadget_source: str, gadget_config: str):
+    def add_gadget_to_apk(self, architecture: str,
+                          gadget_source: str, gadget_config: str,
+                          libfridagadget_name: str = 'libfrida-gadget.so'):
         """
             Copies a frida gadget for a specific architecture to
             an extracted APK's lib path.
@@ -880,9 +882,12 @@ class AndroidPatcher(BasePlatformPatcher):
             :param architecture:
             :param gadget_source:
             :param gadget_config:
+            :param libfridagadget_name:
             :return:
         """
         self.architecture = architecture
+        self.libfridagadget_name = libfridagadget_name
+        self.libfridagadgetconfig_name = libfridagadget_name.replace('.so', '.config.so')
 
         libs_path = os.path.join(self.apk_temp_directory, 'lib', architecture)
 
@@ -892,11 +897,11 @@ class AndroidPatcher(BasePlatformPatcher):
             os.makedirs(libs_path)
 
         click.secho('Copying Frida gadget to libs path...', fg='green', dim=True)
-        shutil.copyfile(gadget_source, os.path.join(libs_path, 'libfrida-gadget.so'))
+        shutil.copyfile(gadget_source, os.path.join(libs_path, self.libfridagadget_name))
 
         if gadget_config:
             click.secho('Adding a gadget configuration file...', fg='green')
-            shutil.copyfile(gadget_config, os.path.join(libs_path, 'libfrida-gadget.config.so'))
+            shutil.copyfile(gadget_config, os.path.join(libs_path, self.libfridagadgetconfig_name))
 
     def build_new_apk(self, use_aapt2: bool = False):
         """

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ requests
 flask
 pygments
 litecli>=1.3.0
+lief


### PR DESCRIPTION
Hi,

Here are a few proposals for enhancements of the `patchapk` function, in line with https://github.com/sensepost/objection/discussions/582:

-[x] Try to make the default value of flags and arguments clearer to the reader, through the `--help` interface. Everything enabled by default should now be explicitly stated as such.
- [x] Inject `libfrida-gadget.so` by adding it in existing shared libraries if possible, and resort to Activity patching if this is not possible.
- [x] Let user specify an alternative name of the Frida gadget library to help dodge (basic) anti-frida measures.
- [x] Use a fuzzy matching of libraries folders inside an APK. If a user uses the base nomenclature from Frida (`frida-gadget-xxx-arm64.so.xz` => `arm64`) as provided architecture, it would now match a folder such as `arm64-v8a` inside the unpacked APK tree.
- [x] Default to `aapt2` for repacking. As far as I understand and experimented, `aapt2` should work out of the box for most cases, while regular `aapt` would often fail on some resources. Is there a specific reason for keeping `aapt` as default?

Best,