### PR TITLE
fix(agent)：check and wait for the currentApplication is ready

### DIFF
--- a/agent/src/android/lib/libjava.ts
+++ b/agent/src/android/lib/libjava.ts
@@ -3,22 +3,46 @@
 // rpc export will sniff and resolve before returning
 // the result when its ready.
 export const wrapJavaPerform = (fn: any): Promise<any> => {
-  return new Promise((resolve, reject) => {
-    Java.perform(() => {
-      try {
-        resolve(fn());
-      } catch (e) {
-        reject(e);
-      }
+    return new Promise((resolve, reject) => {
+        // check and wait for the currentApplication is ready
+        function waitForApplicationReady(callback) {
+            if (global.appIsReady != null) {
+                callback();
+                return;
+            }
+
+            if (Java.use("android.app.ActivityThread").currentApplication() != null) {
+                callback();
+                global.appIsReady = true;
+                return;
+            }
+            //log only once
+            if (global.log_waitAppReady == null) {
+                global.log_waitAppReady = true;
+                console.log("wait for currentApplication to be ready..");
+            }
+            setTimeout(() => {
+                waitForApplicationReady(callback);
+            }, 10);
+        }
+
+        waitForApplicationReady(() => {
+            Java.perform(() => {
+                try {
+                    resolve(fn());
+                } catch (e) {
+                    reject(e);
+                }
+            });
+        });
     });
-  });
 };
 
 export const getApplicationContext = (): any => {
-  const ActivityThread = Java.use("android.app.ActivityThread");
-  const currentApplication = ActivityThread.currentApplication();
+    const ActivityThread = Java.use("android.app.ActivityThread");
+    const currentApplication = ActivityThread.currentApplication();
 
-  return currentApplication.getApplicationContext();
+    return currentApplication.getApplicationContext();
 };
 
 // A helper method to access the R class for the app.
@@ -28,7 +52,7 @@ export const getApplicationContext = (): any => {
 // Using this method, the above example would be:
 //  R("content_frame", "id")
 export const R = (name: string, type: string): any => {
-  const context = getApplicationContext();
-  // https://github.com/bitpay/android-sdk/issues/14#issue-202495610
-  return context.getResources().getIdentifier(name, type, context.getPackageName());
+    const context = getApplicationContext();
+    // https://github.com/bitpay/android-sdk/issues/14#issue-202495610
+    return context.getResources().getIdentifier(name, type, context.getPackageName());
 };


### PR DESCRIPTION
fix a bug that **Java.use("android.app.ActivityThread").currentApplication()** return **null** in the early stage of the application startup.
just check and wait for it become ready at the frist time.
the error log as follow:

```shell 
$ objection -g com.tencent.mobileqq explore
Using USB device `IN2020`
Agent injected and responds ok!
Traceback (most recent call last):
  File "C:\Python311\Scripts\objection-script.py", line 33, in <module>
    sys.exit(load_entry_point('objection==1.11.0', 'console_scripts', 'objection')())
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Python311\Lib\site-packages\click\core.py", line 1130, in __call__
    return self.main(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Python311\Lib\site-packages\click\core.py", line 1055, in main
    rv = self.invoke(ctx)
         ^^^^^^^^^^^^^^^^
  File "C:\Python311\Lib\site-packages\click\core.py", line 1657, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Python311\Lib\site-packages\click\core.py", line 1404, in invoke
    return ctx.invoke(self.callback, **ctx.params)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Python311\Lib\site-packages\click\core.py", line 760, in invoke
    return __callback(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Python311\Lib\site-packages\objection\console\cli.py", line 156, in explore
    device_info = get_device_info()
                  ^^^^^^^^^^^^^^^^^
  File "C:\Python311\Lib\site-packages\objection\commands\device.py", line 41, in get_device_info
    package_info = api.env_android()
                   ^^^^^^^^^^^^^^^^^
  File "C:\Python311\Lib\site-packages\frida\core.py", line 179, in method
    return script._rpc_request("call", js_name, args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Python311\Lib\site-packages\frida\core.py", line 86, in wrapper
    return f(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^
  File "C:\Python311\Lib\site-packages\frida\core.py", line 491, in _rpc_request
    raise result.error
frida.core.RPCException: TypeError: cannot read property 'getApplicationContext' of null
    at getApplicationContext (/script1.js:18857)
    at <anonymous> (/script1.js:19469)
    at <anonymous> (/script1.js:18835)
    at <anonymous> (frida/node_modules/frida-java-bridge/lib/vm.js:12)
    at _performPendingVmOps (frida/node_modules/frida-java-bridge/index.js:250)
    at <anonymous> (frida/node_modules/frida-java-bridge/index.js:242)
    at apply (native)
    at ne (frida/node_modules/frida-java-bridge/lib/class-factory.js:673)
    at <anonymous> (frida/node_modules/frida-java-bridge/lib/class-factory.js:651)
Asking jobs to stop...
Unloading objection agent...
```