### PR TITLE
(feat) Added memory replace command.

### DIFF
--- a/agent/src/generic/memory.ts
+++ b/agent/src/generic/memory.ts
@@ -45,6 +45,27 @@ export const search = (pattern: string, onlyOffsets: boolean = false): string[] 
   return addresses.reduce((a, b) => a.concat(b));
 };
 
+export const replace = (pattern: string, replace: number[]): string[] => {
+  const addresses = listRanges("rw-")
+    .map((range) => {
+      return Memory.scanSync(range.base, range.size, pattern)
+        .map((match) => {
+          try {
+            match.address.writeByteArray(replace);  
+          } catch (error) {
+            return "Failed to replace at " + match.address.toString();
+          }
+          return match.address.toString();
+        });
+    }).filter((m) => m.length !== 0);
+
+  if (addresses.length <= 0) {
+    return [];
+  }
+
+  return addresses.reduce((a, b) => a.concat(b));
+};
+
 export const write = (address: string, value: number[]): void => {
   new NativePointer(address).writeByteArray(value);
 };

--- a/agent/src/generic/memory.ts
+++ b/agent/src/generic/memory.ts
@@ -45,25 +45,11 @@ export const search = (pattern: string, onlyOffsets: boolean = false): string[] 
   return addresses.reduce((a, b) => a.concat(b));
 };
 
-export const replace = (pattern: string, replace: number[]): string[] => {
-  const addresses = listRanges("rw-")
-    .map((range) => {
-      return Memory.scanSync(range.base, range.size, pattern)
-        .map((match) => {
-          try {
-            match.address.writeByteArray(replace);  
-          } catch (error) {
-            return "Failed to replace at " + match.address.toString();
-          }
-          return match.address.toString();
-        });
-    }).filter((m) => m.length !== 0);
-
-  if (addresses.length <= 0) {
-    return [];
-  }
-
-  return addresses.reduce((a, b) => a.concat(b));
+export const replace = (pattern: string, replace: number[]): string[] => {  
+  return search(pattern, true).map((match) => {
+    write(match, replace);
+    return match;
+  })
 };
 
 export const write = (address: string, value: number[]): void => {

--- a/agent/src/rpc/memory.ts
+++ b/agent/src/rpc/memory.ts
@@ -7,5 +7,7 @@ export const memory = {
   memoryListModules: (): Module[] => m.listModules(),
   memoryListRanges: (protection: string): RangeDetails[] => m.listRanges(protection),
   memorySearch: (pattern: string, onlyOffsets: boolean): string[] => m.search(pattern, onlyOffsets),
+  memoryReplace: (pattern: string, replace: number[]): string[] => m.replace(pattern, replace),
   memoryWrite: (address: string, value: number[]): void => m.write(address, value),
+
 };

--- a/objection/console/commands.py
+++ b/objection/console/commands.py
@@ -225,6 +225,12 @@ COMMANDS = {
                 'exec': memory.find_pattern
             },
 
+            'replace': {
+                'meta': 'Search and replace pattern in the applications memory',
+                'flags': ['--string-pattern', '--string-replace'],
+                'exec': memory.replace_pattern
+            },
+
             'write': {
                 'meta': 'Write raw bytes to a memory address. Use with caution!',
                 'flags': ['--string'],

--- a/tests/commands/test_memory.py
+++ b/tests/commands/test_memory.py
@@ -2,7 +2,7 @@ import unittest
 from unittest import mock
 
 from objection.commands.memory import _is_string_input, dump_all, dump_from_base, list_modules, list_exports, \
-    find_pattern
+    find_pattern, replace_pattern
 from ..helpers import capture
 
 
@@ -206,6 +206,55 @@ Pattern matched at 1 addresses
 
         expected_output = """Searching for: 41 41 41
 Pattern matched at 1 addresses
+0x08000000
+"""
+
+        self.assertEqual(output, expected_output)
+
+
+    def test_replace_pattern_validates_arguments(self):
+        with capture(replace_pattern, []) as o:
+            output = o
+
+        self.assertEqual(output, 'Usage: memory replace "<search pattern eg: 41 41 ?? 41>" "<replace value eg: 41 50>" (--string-pattern) (--string-replace)\n')
+
+    @mock.patch('objection.state.connection.state_connection.get_api')
+    def test_replace_pattern_without_string_argument(self, mock_api):
+        mock_api.return_value.memory_replace.return_value = ['0x08000000']
+
+        with capture(replace_pattern, ['41 41 41','41 42']) as o:
+            output = o
+
+        expected_output = """Searching for: 41 41 41, replacing with: 41 42
+Pattern replaced at 1 addresses
+0x08000000
+"""
+
+        self.assertEqual(output, expected_output)
+
+    @mock.patch('objection.state.connection.state_connection.get_api')
+    def test_replace_pattern_with_string_argument(self, mock_api):
+        mock_api.return_value.memory_replace.return_value = ['0x08000000']
+
+        with capture(replace_pattern, ['foo-bar-baz', '41 41', '--string-pattern']) as o:
+            output = o
+
+        expected_output = """Searching for: 66 6f 6f 2d 62 61 72 2d 62 61 7a, replacing with: 41 41
+Pattern replaced at 1 addresses
+0x08000000
+"""
+
+        self.assertEqual(output, expected_output)
+
+    @mock.patch('objection.state.connection.state_connection.get_api')
+    def test_replace_pattern_without_string_argument_with_offets_only(self, mock_api):
+        mock_api.return_value.memory_replace.return_value = ['0x08000000']
+
+        with capture(replace_pattern, ['41 41 41', 'ABC', '--string-replace']) as o:
+            output = o
+
+        expected_output = """Searching for: 41 41 41, replacing with: ABC
+Pattern replaced at 1 addresses
 0x08000000
 """
 


### PR DESCRIPTION
Added `memory replace "<search pattern eg: 41 41 ?? 41>" "<replace value eg: 41 50>" (--string-pattern) (--string-replace)` command.
> `--string-pattern` is used to specify the search input is a string.
> `--string-replace` is used to specify the replace input is a string.
Only searches ('rw-') memory space, can look at adding support for searching all memory and automatically changing perms with frida's `Memory.protect()`.

Added some simple tests for it, though they by no means cover everything.

The naming of some of the parameters may not be the best, though I was not sure what else to call them.