### PR TITLE
Expand use_aapt2 cli arg for which aapt version we use for badge dumping

### DIFF
--- a/objection/commands/mobile_packages.py
+++ b/objection/commands/mobile_packages.py
@@ -176,7 +176,7 @@ def patch_android_apk(source: str, architecture: str, pause: bool, skip_cleanup:
 
     click.secho('Patcher will be using Gadget version: {0}'.format(github_version), fg='green')
 
-    patcher = AndroidPatcher(skip_cleanup=skip_cleanup, skip_resources=skip_resources, manifest=manifest, only_main_classes=only_main_classes)
+    patcher = AndroidPatcher(skip_cleanup=skip_cleanup, skip_resources=skip_resources, manifest=manifest, only_main_classes=only_main_classes, use_aapt2=use_aapt2)
 
     # ensure that we have all of the commandline requirements
     if not patcher.are_requirements_met():

--- a/objection/console/cli.py
+++ b/objection/console/cli.py
@@ -268,7 +268,7 @@ def patchipa(source: str, gadget_version: str, codesign_signature: str, provisio
               help='Skip signing the apk file.', show_default=False)
 @click.option('--target-class', '-t', help='The target class to patch.', default=None)
 @click.option('--use-aapt2', '-2', is_flag=True, default=False,
-              help='Use the aapt2 binary instead of aapt as part of the apktool processing.', show_default=False)
+              help='Use the aapt2 binary instead of aapt as part of the apktool processing and for badge dumping.', show_default=False)
 @click.option('--gadget-config', '-c', default=None, help=(
         'The gadget configuration file to use. '
         'Refer to https://frida.re/docs/gadget/ for more information.'), show_default=False)

--- a/objection/utils/patchers/android.py
+++ b/objection/utils/patchers/android.py
@@ -199,7 +199,9 @@ class AndroidPatcher(BasePlatformPatcher):
         }
     }
 
-    def __init__(self, skip_cleanup: bool = False, skip_resources: bool = False, manifest: str = None, only_main_classes: bool = False):
+    def __init__(self, skip_cleanup: bool = False, skip_resources: bool = False, manifest: str = None, only_main_classes: bool = False, use_aapt2: bool = False):
+        if use_aapt2:
+            self.required_commands['aapt2'] =  {'installation': 'apt install aapt2 (Kali Linux)'}
         super(AndroidPatcher, self).__init__()
 
         self.apk_source = None
@@ -210,6 +212,7 @@ class AndroidPatcher(BasePlatformPatcher):
         self.skip_cleanup = skip_cleanup
         self.skip_resources = skip_resources
         self.manifest = manifest
+        self.use_aapt2 = use_aapt2
 
         self.keystore = os.path.join(os.path.abspath(os.path.dirname(__file__)), '../assets', 'objection.jks')
         self.netsec_config = os.path.join(os.path.abspath(os.path.dirname(__file__)), '../assets',
@@ -304,15 +307,16 @@ class AndroidPatcher(BasePlatformPatcher):
         """
 
         if not self.aapt:
-            o = delegator.run(self.list2cmdline([
-                self.required_commands['aapt']['location'],
+            cmd = self.list2cmdline([
+                self.required_commands['aapt2' if self.use_aapt2 else 'aapt']['location'],
                 'dump',
                 'badging',
                 self.apk_source
-            ]), timeout=self.command_run_timeout)
+            ])
+            o = delegator.run(cmd, timeout=self.command_run_timeout)
 
             if len(o.err) > 0:
-                click.secho('An error may have occurred while running aapt.', fg='red')
+                click.secho(f'An error may have occurred while running aapt cmd: {cmd}.', fg='red')
                 click.secho(o.err, fg='red')
 
             self.aapt = o.out


### PR DESCRIPTION
Fixes newer apk patching that aapt cannot handle

There are various reasons aapt dump badging may fail with newer APKs.   Given google has moved on to aapt2 for nearly everything we should be using it instead of aapt for dumping I would assume.  I don't know if there is ever a negative for using aapt2 dump badging but this was a simple call.  We already have a --use-aapt2 command used for when we call apktool lets just hijack that arg to also decide if we use it for badge dumping.  This should resolve a few of the bugs were people may not have been able to patch apks due to `Unable to determine launchable activity` without manually specifying the target class.

If someone thinks aapt2 might be more likely to fail during dumping for some reason we could add a second use-aapt2 flag just for this but that seems like overkill.

