### PR TITLE
Fixed ios keychain dump command to correctly return keychain data

### DIFF
--- a/agent/src/ios/keychain.ts
+++ b/agent/src/ios/keychain.ts
@@ -110,8 +110,7 @@ const enumerateKeychain = (): IKeychainData[] => {
     return data;
   });
   
-  const keyChainData: IKeychainData[] = [];
-  keyChainData.concat(...itemClassResults).filter((n) => n !== undefined);
+  const keyChainData: IKeychainData[] = [].concat(...itemClassResults).filter((n) => n !== undefined);
 
   return keyChainData;
 };


### PR DESCRIPTION
The `ios keychain dump` command currently does not return keychain items as expected. This problem arises because the concatenation and filtering operation on the `keyChainData` array at line 114 in `agent/src/ios/keychain.ts` generates a new array without updating the `keyChainData` reference. As a result, the `enumerateKeychain` function always returns an empty `IKeychainData[]` object.

This PR addresses the problem by ensuring that the concatenated and filtered data is directly assigned to the `keyChainData` array. With this change, the function now returns the correct keychain query results.

Special thanks to MWR CyberSec for providing the time and opportunity to investigate and implement this fix.