### PR TITLE
Added apktool -j; Fixes OOM errors when patching an APK

### DIFF
--- a/agent/src/android/intent.ts
+++ b/agent/src/android/intent.ts
@@ -70,7 +70,7 @@ export const startService = (serviceClass: string): Promise<void> => {
 
 // Analyzes and Detects Android Implicit Intents
 // https://developer.android.com/guide/components/intents-filters#Types
-export const analyzeImplicits = (): Promise<void> => {
+export const analyzeImplicits = (backtrace = false): Promise<void> => {
 
   const job: IJob = {
     identifier: jobs.identifier(),
@@ -84,8 +84,8 @@ export const analyzeImplicits = (): Promise<void> => {
       { className: "android.app.Activity", methodName: "startActivityForResult" },
       { className: "android.app.Activity", methodName: "onActivityResult" },
       { className: "androidx.activity.ComponentActivity", methodName: "onActivityResult" },
-      { className: "android.content.Context", methodName: "startActivity"},
-      { className: "android.content.BroadcastReceiver", methodName: "onReceive"}
+      { className: "android.content.Context", methodName: "startActivity" },
+      { className: "android.content.BroadcastReceiver", methodName: "onReceive" }
       // Add other classes and methods as needed
     ];
 
@@ -97,7 +97,7 @@ export const analyzeImplicits = (): Promise<void> => {
           overload.implementation = function (...args: any[]): any {
             args.forEach(arg => {
               if (arg && arg.$className === "android.content.Intent") {
-                analyseIntent(`${hook.className}::${hook.methodName}`, arg);
+                analyseIntent(`${hook.className}::${hook.methodName}`, arg, backtrace);
               }
             });
             return overload.apply(this, args);

--- a/agent/src/android/lib/intentUtils.ts
+++ b/agent/src/android/lib/intentUtils.ts
@@ -1,6 +1,6 @@
 import { colors as c } from "../../lib/color.js";
 
-export const analyseIntent = (methodName: string, intent: Java.Wrapper): void => {
+export const analyseIntent = (methodName: string, intent: Java.Wrapper, backtrace = false): void => {
   try {
     send(`\nAnalyzing Intent from: ${c.green(`${methodName}`)}`);
 
@@ -10,11 +10,17 @@ export const analyseIntent = (methodName: string, intent: Java.Wrapper): void =>
       send(`[-] ${c.green('Intent Type: Explicit Intent')}`);
     } else {
       send(`[+] ${c.redBright('Intent Type: Implicit Intent Detected!')}`);
-      
+      if (backtrace) {
+        console.log(Java.use('android.util.Log')
+          .getStackTraceString(Java.use('java.lang.Exception').$new())
+        )
+      }
+
+
       // Log intent details
-      send(`[+] Action: ${ `${c.green(`${intent.getAction()}`)}` || `${c.redBright(`[None]`)}` }`);
-      send(`[+] Data URI: ${ `${c.green(`${intent.getDataString()}`)}` || `${c.redBright(`[None]`)}` }`);
-      send(`[+] Type: ${ `${c.green(`${intent.getType()}`)}` || `${c.redBright(`[None]`)}` }`);
+      send(`[+] Action: ${`${c.green(`${intent.getAction()}`)}` || `${c.redBright(`[None]`)}`}`);
+      send(`[+] Data URI: ${`${c.green(`${intent.getDataString()}`)}` || `${c.redBright(`[None]`)}`}`);
+      send(`[+] Type: ${`${c.green(`${intent.getType()}`)}` || `${c.redBright(`[None]`)}`}`);
       send(`[+] Flags: ${c.green(`0x${intent.getFlags().toString(16)}`)}`);
 
       // Categories

--- a/agent/src/rpc/android.ts
+++ b/agent/src/rpc/android.ts
@@ -71,7 +71,7 @@ export const android = {
   // android intents
   androidIntentStartActivity: (activityClass: string): Promise<void> => intent.startActivity(activityClass),
   androidIntentStartService: (serviceClass: string): Promise<void> => intent.startService(serviceClass),
-  androidIntentAnalyze: (): Promise<void> => intent.analyzeImplicits(),
+  androidIntentAnalyze: (backtrace: boolean): Promise<void> => intent.analyzeImplicits(backtrace),
 
   // android keystore
   androidKeystoreClear: () => keystore.clear(),

--- a/objection/commands/android/intents.py
+++ b/objection/commands/android/intents.py
@@ -3,12 +3,25 @@ import click
 from objection.state.connection import state_connection
 from objection.utils.helpers import clean_argument_flags
 
+def _should_dump_backtrace(args: list) -> bool:
+    """
+        Check if --dump-backtrace is part of the arguments.
+
+        :param args:
+        :return:
+    """
+
+    return '--dump-backtrace' in args
+
+
 def analyze_implicit_intents(args: list) -> None:
     """
         Analyzes implicit intents in hooked methods.
     """
     api = state_connection.get_api()
-    api.android_intent_analyze()
+    backtrace = _should_dump_backtrace(args)
+    api.android_intent_analyze(backtrace)
+    
     click.secho('Started implicit intent analysis', bold=True)
 
 def launch_activity(args: list) -> None:

--- a/objection/commands/mobile_packages.py
+++ b/objection/commands/mobile_packages.py
@@ -101,7 +101,7 @@ def patch_android_apk(source: str, architecture: str, pause: bool, skip_cleanup:
                       network_security_config: bool = False, target_class: str = None,
                       use_aapt2: bool = False, gadget_config: str = None, script_source: str = None,
                       ignore_nativelibs: bool = True, manifest: str = None, skip_signing: bool = False,
-                      only_main_classes: bool = False) -> None:
+                      only_main_classes: bool = False, fix_concurrency_to = None) -> None:
     """
         Patches an Android APK by extracting, patching SMALI, repackaging
         and signing a new APK.
@@ -122,6 +122,7 @@ def patch_android_apk(source: str, architecture: str, pause: bool, skip_cleanup:
         :param skip_signing:
         :param ignore_nativelibs:
         :param only_main_classes:
+        :param fix_concurrency_to:
 
         :return:
     """
@@ -192,7 +193,7 @@ def patch_android_apk(source: str, architecture: str, pause: bool, skip_cleanup:
 
     # work on patching the APK
     patcher.set_apk_source(source=source)
-    patcher.unpack_apk()
+    patcher.unpack_apk(fix_concurrency_to=fix_concurrency_to)
     patcher.inject_internet_permission()
 
     if not ignore_nativelibs:
@@ -222,7 +223,7 @@ def patch_android_apk(source: str, architecture: str, pause: bool, skip_cleanup:
 
         input('Press ENTER to continue...')
 
-    patcher.build_new_apk(use_aapt2=use_aapt2)
+    patcher.build_new_apk(use_aapt2=use_aapt2, fix_concurrency_to=fix_concurrency_to)
     patcher.zipalign_apk()
     if not skip_signing:
         patcher.sign_apk()

--- a/objection/console/cli.py
+++ b/objection/console/cli.py
@@ -279,9 +279,11 @@ def patchipa(source: str, gadget_version: str, codesign_signature: str, provisio
               help='Do not change the extractNativeLibs flag in the AndroidManifest.xml.', show_default=False)
 @click.option('--manifest', '-m', help='A decoded AndroidManifest.xml file to read.', default=None)
 @click.option('--only-main-classes', help="Only patch classes that are in the main dex file.", is_flag=True, default=False)
+@click.option('--fix-concurrency-to', '-j', help="Only use N threads for repackaging - set to 1 if running into OOM errors.", default=None)
+
 def patchapk(source: str, architecture: str, gadget_version: str, pause: bool, skip_cleanup: bool,
              enable_debug: bool, skip_resources: bool, network_security_config: bool, target_class: str,
-             use_aapt2: bool, gadget_config: str, script_source: str, ignore_nativelibs: bool, manifest: str, skip_signing: bool, only_main_classes:bool = False) -> None:
+             use_aapt2: bool, gadget_config: str, script_source: str, ignore_nativelibs: bool, manifest: str, skip_signing: bool, only_main_classes:bool = False, fix_concurrency_to = None) -> None:
     """
         Patch an APK with the frida-gadget.so.
     """

--- a/objection/console/commands.py
+++ b/objection/console/commands.py
@@ -460,7 +460,8 @@ COMMANDS = {
                     },
                     'implicit_intents': {
                         'meta': 'Analyze implicit intents',
-                        'exec': intents.analyze_implicit_intents
+                        'exec': intents.analyze_implicit_intents,
+                        'flags': ['--dump-backtrace'],
                     }
                 }
             },

--- a/objection/console/helpfiles/android.intent.implicit_intents.txt
+++ b/objection/console/helpfiles/android.intent.implicit_intents.txt
@@ -5,4 +5,7 @@ Usage: android intent implicit_intents
 Starts a hook to analyze implicit intents during runtime.
 
 Examples:
-   android intent implicit_intents
+   android intent implicit_intents 
+
+To add a backtrace:
+   android intent implicit_intents --dump-backtrace


### PR DESCRIPTION
Sorry don't have a public test application for this, but did test on my side. If you have an APK that is particularly large (or has a weird dependency tree) you can run out of memory with patchapk since apktool(2) will try to use multiple threads. The solution I came across was to instruct it to be single threaded using -j 1

This PR adds that functionality:

```sh
objection patch_apk -s flappy.bird.apk -j 1
```

By default it will still use whatever apktool(2) uses for -j, but if you add the flag it'll use your int.