### PR TITLE
Concurrency control foor apktool

### DIFF
--- a/objection/commands/mobile_packages.py
+++ b/objection/commands/mobile_packages.py
@@ -101,7 +101,7 @@ def patch_android_apk(source: str, architecture: str, pause: bool, skip_cleanup:
                       network_security_config: bool = False, target_class: str = None,
                       use_aapt2: bool = False, gadget_config: str = None, script_source: str = None,
                       ignore_nativelibs: bool = True, manifest: str = None, skip_signing: bool = False,
-                      only_main_classes: bool = False) -> None:
+                      only_main_classes: bool = False, fix_concurrency_to = None) -> None:
     """
         Patches an Android APK by extracting, patching SMALI, repackaging
         and signing a new APK.
@@ -122,6 +122,7 @@ def patch_android_apk(source: str, architecture: str, pause: bool, skip_cleanup:
         :param skip_signing:
         :param ignore_nativelibs:
         :param only_main_classes:
+        :param fix_concurrency_to:
 
         :return:
     """
@@ -192,7 +193,7 @@ def patch_android_apk(source: str, architecture: str, pause: bool, skip_cleanup:
 
     # work on patching the APK
     patcher.set_apk_source(source=source)
-    patcher.unpack_apk()
+    patcher.unpack_apk(fix_concurrency_to=fix_concurrency_to)
     patcher.inject_internet_permission()
 
     if not ignore_nativelibs:
@@ -222,7 +223,7 @@ def patch_android_apk(source: str, architecture: str, pause: bool, skip_cleanup:
 
         input('Press ENTER to continue...')
 
-    patcher.build_new_apk(use_aapt2=use_aapt2)
+    patcher.build_new_apk(use_aapt2=use_aapt2, fix_concurrency_to=fix_concurrency_to)
     patcher.zipalign_apk()
     if not skip_signing:
         patcher.sign_apk()

--- a/objection/console/cli.py
+++ b/objection/console/cli.py
@@ -279,9 +279,11 @@ def patchipa(source: str, gadget_version: str, codesign_signature: str, provisio
               help='Do not change the extractNativeLibs flag in the AndroidManifest.xml.', show_default=False)
 @click.option('--manifest', '-m', help='A decoded AndroidManifest.xml file to read.', default=None)
 @click.option('--only-main-classes', help="Only patch classes that are in the main dex file.", is_flag=True, default=False)
+@click.option('--fix-concurrency-to', '-j', help="Only use N threads for repackaging - set to 1 if running into OOM errors.", default=None)
+
 def patchapk(source: str, architecture: str, gadget_version: str, pause: bool, skip_cleanup: bool,
              enable_debug: bool, skip_resources: bool, network_security_config: bool, target_class: str,
-             use_aapt2: bool, gadget_config: str, script_source: str, ignore_nativelibs: bool, manifest: str, skip_signing: bool, only_main_classes:bool = False) -> None:
+             use_aapt2: bool, gadget_config: str, script_source: str, ignore_nativelibs: bool, manifest: str, skip_signing: bool, only_main_classes:bool = False, fix_concurrency_to = None) -> None:
     """
         Patch an APK with the frida-gadget.so.
     """

--- a/objection/utils/patchers/android.py
+++ b/objection/utils/patchers/android.py
@@ -886,24 +886,16 @@ class AndroidPatcher(BasePlatformPatcher):
         """
 
         click.secho('Rebuilding the APK with the frida-gadget loaded...', fg='green', dim=True)
-        if fix_concurrency_to is None:
-            o = delegator.run(
-                self.list2cmdline([self.required_commands['apktool']['location'],
-                                'build',
-                                self.apk_temp_directory,
-                                ] + (['--use-aapt2'] if use_aapt2 else []) + [
-                                    '-o',
-                                    self.apk_temp_frida_patched
-                                ]), timeout=self.command_run_timeout)
-        else:
-            o = delegator.run(
-                self.list2cmdline([self.required_commands['apktool']['location'],
-                                'build','-j',fix_concurrency_to,
-                                self.apk_temp_directory,
-                                ] + (['--use-aapt2'] if use_aapt2 else []) + [
-                                    '-o',
-                                    self.apk_temp_frida_patched
-                                ]), timeout=self.command_run_timeout)
+        o = delegator.run(
+            self.list2cmdline([self.required_commands['apktool']['location'],
+                            'build',
+                            self.apk_temp_directory,
+                            ] + (['--use-aapt2'] if use_aapt2 else []) + [
+                                '-o',
+                                self.apk_temp_frida_patched
+                            ]+ ([] if fix_concurrency_to is None else ['-j', fix_concurrency_to]))
+                            , timeout=self.command_run_timeout)
+        
 
         if len(o.err) > 0:
             click.secho(('Rebuilding the APK may have failed. Read the following '

--- a/objection/utils/patchers/android.py
+++ b/objection/utils/patchers/android.py
@@ -399,29 +399,17 @@ class AndroidPatcher(BasePlatformPatcher):
         """
 
         click.secho('Unpacking {0}'.format(self.apk_source), dim=True)
-        if fix_concurrency_to is None:
-            o = delegator.run(self.list2cmdline([
-                self.required_commands['apktool']['location'],
-                'decode',
-                '-f',
-                '-r' if self.skip_resources else '',
-                '--only-main-classes' if self.only_main_classes else '',
-                '-o',
-                self.apk_temp_directory,
-                self.apk_source
-            ]), timeout=self.command_run_timeout)
-        else:
-            o = delegator.run(self.list2cmdline([
-                self.required_commands['apktool']['location'],
-                'decode',
-                '-j', fix_concurrency_to,
-                '-f',
-                '-r' if self.skip_resources else '',
-                '--only-main-classes' if self.only_main_classes else '',
-                '-o',
-                self.apk_temp_directory,
-                self.apk_source
-            ]), timeout=self.command_run_timeout)
+
+        o = delegator.run(self.list2cmdline([
+            self.required_commands['apktool']['location'],
+            'decode',
+            '-f',
+            '-r' if self.skip_resources else '',
+            '--only-main-classes' if self.only_main_classes else '',
+            '-o',
+            self.apk_temp_directory,
+            self.apk_source
+        ] + ([] if fix_concurrency_to is None else ['-j', fix_concurrency_to])), timeout=self.command_run_timeout)
 
         if len(o.err) > 0:
             click.secho('An error may have occurred while extracting the APK.', fg='red')


### PR DESCRIPTION
Sorry don't have a public test application for this, but did test on my side. If you have an APK that is particularly large (or has a weird dependency tree) you can run out of memory with patchapk since apktool(2) will try to use multiple threads. The solution I came across was to instruct it to be single threaded using -j 1

This PR adds that functionality:
```
objection patch_apk -s flappy.bird.apk -j 1
```

By default it will still use whatever apktool(2) uses for -j, but if you add the flag it'll use your int. Sorry about the dangling closed PR, needed a good git refresher :) 