### PR TITLE
Added optional backtrace for implicit intent analyzer

### DIFF
--- a/agent/src/android/intent.ts
+++ b/agent/src/android/intent.ts
@@ -70,7 +70,7 @@ export const startService = (serviceClass: string): Promise<void> => {
 
 // Analyzes and Detects Android Implicit Intents
 // https://developer.android.com/guide/components/intents-filters#Types
-export const analyzeImplicits = (): Promise<void> => {
+export const analyzeImplicits = (backtrace = false): Promise<void> => {
 
   const job: IJob = {
     identifier: jobs.identifier(),
@@ -84,8 +84,8 @@ export const analyzeImplicits = (): Promise<void> => {
       { className: "android.app.Activity", methodName: "startActivityForResult" },
       { className: "android.app.Activity", methodName: "onActivityResult" },
       { className: "androidx.activity.ComponentActivity", methodName: "onActivityResult" },
-      { className: "android.content.Context", methodName: "startActivity"},
-      { className: "android.content.BroadcastReceiver", methodName: "onReceive"}
+      { className: "android.content.Context", methodName: "startActivity" },
+      { className: "android.content.BroadcastReceiver", methodName: "onReceive" }
       // Add other classes and methods as needed
     ];
 
@@ -97,7 +97,7 @@ export const analyzeImplicits = (): Promise<void> => {
           overload.implementation = function (...args: any[]): any {
             args.forEach(arg => {
               if (arg && arg.$className === "android.content.Intent") {
-                analyseIntent(`${hook.className}::${hook.methodName}`, arg);
+                analyseIntent(`${hook.className}::${hook.methodName}`, arg, backtrace = backtrace);
               }
             });
             return overload.apply(this, args);

--- a/agent/src/android/lib/intentUtils.ts
+++ b/agent/src/android/lib/intentUtils.ts
@@ -1,6 +1,6 @@
 import { colors as c } from "../../lib/color.js";
 
-export const analyseIntent = (methodName: string, intent: Java.Wrapper): void => {
+export const analyseIntent = (methodName: string, intent: Java.Wrapper, backtrace: boolean = false): void => {
   try {
     send(`\nAnalyzing Intent from: ${c.green(`${methodName}`)}`);
 
@@ -10,11 +10,17 @@ export const analyseIntent = (methodName: string, intent: Java.Wrapper): void =>
       send(`[-] ${c.green('Intent Type: Explicit Intent')}`);
     } else {
       send(`[+] ${c.redBright('Intent Type: Implicit Intent Detected!')}`);
-      
+      if (backtrace) {
+        send(
+          Java.use('android.util.Log')
+            .getStackTraceString(Java.use('java.lang.Exception').$new())
+        )
+      }
+
       // Log intent details
-      send(`[+] Action: ${ `${c.green(`${intent.getAction()}`)}` || `${c.redBright(`[None]`)}` }`);
-      send(`[+] Data URI: ${ `${c.green(`${intent.getDataString()}`)}` || `${c.redBright(`[None]`)}` }`);
-      send(`[+] Type: ${ `${c.green(`${intent.getType()}`)}` || `${c.redBright(`[None]`)}` }`);
+      send(`[+] Action: ${`${c.green(`${intent.getAction()}`)}` || `${c.redBright(`[None]`)}`}`);
+      send(`[+] Data URI: ${`${c.green(`${intent.getDataString()}`)}` || `${c.redBright(`[None]`)}`}`);
+      send(`[+] Type: ${`${c.green(`${intent.getType()}`)}` || `${c.redBright(`[None]`)}`}`);
       send(`[+] Flags: ${c.green(`0x${intent.getFlags().toString(16)}`)}`);
 
       // Categories

--- a/agent/src/rpc/android.ts
+++ b/agent/src/rpc/android.ts
@@ -71,7 +71,7 @@ export const android = {
   // android intents
   androidIntentStartActivity: (activityClass: string): Promise<void> => intent.startActivity(activityClass),
   androidIntentStartService: (serviceClass: string): Promise<void> => intent.startService(serviceClass),
-  androidIntentAnalyze: (): Promise<void> => intent.analyzeImplicits(),
+  androidIntentAnalyze: (backtrace: boolean = false): Promise<void> => intent.analyzeImplicits(backtrace),
 
   // android keystore
   androidKeystoreClear: () => keystore.clear(),

--- a/objection/commands/android/intents.py
+++ b/objection/commands/android/intents.py
@@ -3,13 +3,29 @@ import click
 from objection.state.connection import state_connection
 from objection.utils.helpers import clean_argument_flags
 
+def _should_dump_backtrace(args: list = None) -> bool:
+    """
+        Check if --dump-backtrace is part of the arguments.
+
+        :param args:
+        :return:
+    """
+
+    return '--dump-backtrace' in args
+
 def analyze_implicit_intents(args: list) -> None:
     """
         Analyzes implicit intents in hooked methods.
     """
     api = state_connection.get_api()
-    api.android_intent_analyze()
-    click.secho('Started implicit intent analysis', bold=True)
+    should_backtrace = _should_dump_backtrace(args)
+
+    api.android_intent_analyze(should_backtrace)
+    if not should_backtrace:
+        click.secho('Started implicit intent analysis', bold=True)
+    else:
+        click.secho('Started implicit intent analysis with backtrace', bold=True)
+
 
 def launch_activity(args: list) -> None:
     """

--- a/objection/console/commands.py
+++ b/objection/console/commands.py
@@ -460,7 +460,8 @@ COMMANDS = {
                     },
                     'implicit_intents': {
                         'meta': 'Analyze implicit intents',
-                        'exec': intents.analyze_implicit_intents
+                        'exec': intents.analyze_implicit_intents,
+                        'flags': ['--dump-backtrace']
                     }
                 }
             },

--- a/objection/console/helpfiles/android.intent.implicit_intents.txt
+++ b/objection/console/helpfiles/android.intent.implicit_intents.txt
@@ -2,7 +2,7 @@ Command: android intent implicit_intents
 
 Usage: android intent implicit_intents
 
-Starts a hook to analyze implicit intents during runtime.
+Starts a hook to analyze implicit intents during runtime. Optionally add a backtrade by adding --dump-backtrace
 
 Examples:
    android intent implicit_intents


### PR DESCRIPTION
Adds a --dump-backtrace flag to the implicit intent monitor. I used a basic activity with an onclick handler as follows for testing:

```kotlin
        binding.fab.setOnClickListener { view ->
                startActivity(Intent("com.mwr.testThing"))
        }
```
Which resulted in:

```
Analyzing Intent from: android.app.Activity::startActivityForResult
(agent) [+] Intent Type: Implicit Intent Detected!
java.lang.Exception
	at android.app.Activity.startActivityForResult(Native Method)
	at androidx.activity.ComponentActivity.startActivityForResult(ComponentActivity.java:761)
	at android.app.Activity.startActivity(Activity.java:5658)
	at android.app.Activity.startActivity(Activity.java:5611)
	at com.example.basic_network_security.MainActivity$onCreate$1$1.invokeSuspend(MainActivity.kt:104)
```