### PR TITLE
(fix) frida v17 changes, webserver disabled.

### DIFF
--- a/agent/package-lock.json
+++ b/agent/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "frida-java-bridge": "^7",
         "frida-objc-bridge": "^8",
-        "frida-screenshot": "^5",
+        "frida-screenshot": "^6",
         "macho-ts": "^0.1.0"
       },
       "devDependencies": {
@@ -603,10 +603,13 @@
       "license": "LGPL-2.0 WITH WxWindows-exception-3.1"
     },
     "node_modules/frida-screenshot": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/frida-screenshot/-/frida-screenshot-5.0.2.tgz",
-      "integrity": "sha512-Rz8Yt6yXiV6TuBZC7xLKx6Zj7zsfirvccM0AuN5Tlw/xh5KsFiBceJHYgA2VUO/WR0ekG8zJcWIDlWnQVLje5w==",
-      "license": "MIT"
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/frida-screenshot/-/frida-screenshot-6.0.0.tgz",
+      "integrity": "sha512-jLK26KpzKkCQ/UwzGoGCUfsWGxXi5UJM0S9usJ/G3p5aR10m2/BK06e0jxwtrIlHEsMuTRSm3M610BfoGGG3kA==",
+      "license": "MIT",
+      "dependencies": {
+        "frida-objc-bridge": "^8.0.4"
+      }
     },
     "node_modules/fs.realpath": {
       "version": "1.0.0",

--- a/agent/package-lock.json
+++ b/agent/package-lock.json
@@ -9,15 +9,15 @@
       "version": "0.0.0",
       "license": "GPL-3.0",
       "dependencies": {
-        "frida-java-bridge": "^6",
-        "frida-objc-bridge": "^7",
+        "frida-java-bridge": "^7",
+        "frida-objc-bridge": "^8",
         "frida-screenshot": "^5",
         "macho-ts": "^0.1.0"
       },
       "devDependencies": {
-        "@types/frida-gum": "^18",
+        "@types/frida-gum": "^19",
         "@types/node": "^18",
-        "frida-compile": "^16",
+        "frida-compile": "^17",
         "tslint": "^6"
       }
     },
@@ -368,10 +368,11 @@
       }
     },
     "node_modules/@types/frida-gum": {
-      "version": "18.7.0",
-      "resolved": "https://registry.npmjs.org/@types/frida-gum/-/frida-gum-18.7.0.tgz",
-      "integrity": "sha512-HhBomXE23fLDAWXEKi3BjJLrlH9wAv9IEQNfO/PaYHQNNbh0Bi06gx6JbXTspVpbqlbVqkWAuU7n6HaS9B6yXA==",
-      "dev": true
+      "version": "19.0.0",
+      "resolved": "https://registry.npmjs.org/@types/frida-gum/-/frida-gum-19.0.0.tgz",
+      "integrity": "sha512-qViK1KwvPEAkajwSUv0wpZvZLiX8xO4JFFCh8dfYZfzSyOEfoE0KliCP/nJSKIKG6N3hXnPowrvPufjs5fLKAA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/node": {
       "version": "18.19.34",
@@ -542,9 +543,9 @@
       }
     },
     "node_modules/frida-compile": {
-      "version": "16.4.1",
-      "resolved": "https://registry.npmjs.org/frida-compile/-/frida-compile-16.4.1.tgz",
-      "integrity": "sha512-xI9HNtUFpHxuKBGXaL6XJAYH1zWTvNJDrHRnz1hp0oS24iPHt6c01Jmm3qljZek3oQWn8HhvfNvrzfgbsKzoBQ==",
+      "version": "17.0.0",
+      "resolved": "https://registry.npmjs.org/frida-compile/-/frida-compile-17.0.0.tgz",
+      "integrity": "sha512-ixJRj14qLH/Z0ckFWd5fKeDMm0W2+2WDpSGnLRgpn0nuCQAbDHRCqVCWtPnV8uzPJmA6XOX0pujsMpYe9q9RRw==",
       "dev": true,
       "dependencies": {
         "@frida/assert": "^3.0.1",
@@ -575,7 +576,7 @@
         "@frida/util": "^1.0.3",
         "@frida/vm": "^2.0.0",
         "commander": "^11.1.0",
-        "frida-fs": "^5.2.3",
+        "frida-fs": "^6.0.0",
         "typed-emitter": "^2.1.0"
       },
       "bin": {
@@ -583,28 +584,29 @@
       }
     },
     "node_modules/frida-fs": {
-      "version": "5.2.5",
-      "resolved": "https://registry.npmjs.org/frida-fs/-/frida-fs-5.2.5.tgz",
-      "integrity": "sha512-Eyb4OqUlcv1/Eq7Q+B9IZmYZIgIM2YjqDojrjmAGzPSSXBuUKwSkuObQcQ8Dup9JTOMIUcSII9/I8DaTe6LFKw==",
-      "dev": true
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/frida-fs/-/frida-fs-6.0.0.tgz",
+      "integrity": "sha512-I0fnKupZh7fU2ixwCIjJnEqNdhfm/SC1ZYBMy58EmeqOWSbjw1Dpy99mJ7BJdbk2KNXJeaBZGxDYLtn0J9S+UA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/frida-java-bridge": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/frida-java-bridge/-/frida-java-bridge-6.3.1.tgz",
-      "integrity": "sha512-CWrR5+dKX+iDnzO2vWpiv8qeW32v4U65MISZa2BhciN9cbinWAAGFBealQ9pXJyaQ6c0hVoZvBAcDgXT3tXacg==",
-      "dependencies": {
-        "jssha": "^3.1.2"
-      }
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/frida-java-bridge/-/frida-java-bridge-7.0.1.tgz",
+      "integrity": "sha512-pyNv12Y+erFgqdbFMsECh1OfqS77E62GeKHtxaBOZUPSpqcEkL0T2/6q/XD2161S4eGYBn6V7zumH2gbxtXK/Q==",
+      "license": "LGPL-2.0 WITH WxWindows-exception-3.1"
     },
     "node_modules/frida-objc-bridge": {
-      "version": "7.0.6",
-      "resolved": "https://registry.npmjs.org/frida-objc-bridge/-/frida-objc-bridge-7.0.6.tgz",
-      "integrity": "sha512-VzSnVWDnv6gybgNJspWHO37D0puWgvkHliJjDZ414sK714lRI56LMYlV1kfzuCYgrElT5mZdrdS1Mu/d9HTpFA=="
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/frida-objc-bridge/-/frida-objc-bridge-8.0.4.tgz",
+      "integrity": "sha512-AUzwq/+TFtblQLTI97UPX22pBcvyG2oUde9380DXbcJ0zXts4n9JDVONHUr03aBowa0Le+bdBoVdCs7jyyjvlg==",
+      "license": "LGPL-2.0 WITH WxWindows-exception-3.1"
     },
     "node_modules/frida-screenshot": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/frida-screenshot/-/frida-screenshot-5.0.0.tgz",
-      "integrity": "sha512-43SVs5VsU6ALT48ImitPKNNec+EljX+GQEm2HFjbJv5YqLM5qNqd4EvbIAgnbzPG5kKBwKjDv9Nt9kfvnERbfQ=="
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/frida-screenshot/-/frida-screenshot-5.0.2.tgz",
+      "integrity": "sha512-Rz8Yt6yXiV6TuBZC7xLKx6Zj7zsfirvccM0AuN5Tlw/xh5KsFiBceJHYgA2VUO/WR0ekG8zJcWIDlWnQVLje5w==",
+      "license": "MIT"
     },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
@@ -735,14 +737,6 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
-      }
-    },
-    "node_modules/jssha": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/jssha/-/jssha-3.3.1.tgz",
-      "integrity": "sha512-VCMZj12FCFMQYcFLPRm/0lOBbLi8uM2BhXPTqw3U4YAfs4AZfiApOoBLoN8cQE60Z50m1MYMTQVCfgF/KaCVhQ==",
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/macho-ts": {

--- a/agent/package.json
+++ b/agent/package.json
@@ -29,15 +29,15 @@
   },
   "homepage": "https://github.com/sensepost/objection#readme",
   "dependencies": {
-    "frida-java-bridge": "^6",
-    "frida-objc-bridge": "^7",
+    "frida-java-bridge": "^7",
+    "frida-objc-bridge": "^8",
     "frida-screenshot": "^5",
     "macho-ts": "^0.1.0"
   },
   "devDependencies": {
-    "@types/frida-gum": "^18",
+    "@types/frida-gum": "^19",
     "@types/node": "^18",
-    "frida-compile": "^16",
+    "frida-compile": "^17",
     "tslint": "^6"
   }
 }

--- a/agent/package.json
+++ b/agent/package.json
@@ -31,7 +31,7 @@
   "dependencies": {
     "frida-java-bridge": "^7",
     "frida-objc-bridge": "^8",
-    "frida-screenshot": "^5",
+    "frida-screenshot": "^6",
     "macho-ts": "^0.1.0"
   },
   "devDependencies": {

--- a/agent/src/android/clipboard.ts
+++ b/agent/src/android/clipboard.ts
@@ -1,3 +1,4 @@
+import Java from "frida-java-bridge";
 import { colors as c } from "../lib/color.js";
 import {
   getApplicationContext,

--- a/agent/src/android/clipboard.ts
+++ b/agent/src/android/clipboard.ts
@@ -1,8 +1,8 @@
-import Java from "frida-java-bridge";
 import { colors as c } from "../lib/color.js";
 import {
   getApplicationContext,
-  wrapJavaPerform
+  wrapJavaPerform, 
+  Java
 } from "./lib/libjava.js";
 import { ClipboardManager } from "./lib/types.js";
 

--- a/agent/src/android/filesystem.ts
+++ b/agent/src/android/filesystem.ts
@@ -1,11 +1,11 @@
-import Java from "frida-java-bridge";
 import * as fs from "frida-fs";
 import { Buffer } from "buffer";
 import { hexStringToBytes } from "../lib/helpers.js";
 import { IAndroidFilesystem } from "./lib/interfaces.js";
 import {
   getApplicationContext,
-  wrapJavaPerform
+  wrapJavaPerform, 
+  Java
 } from "./lib/libjava.js";
 import {
   File,

--- a/agent/src/android/filesystem.ts
+++ b/agent/src/android/filesystem.ts
@@ -1,3 +1,4 @@
+import Java from "frida-java-bridge";
 import * as fs from "frida-fs";
 import { Buffer } from "buffer";
 import { hexStringToBytes } from "../lib/helpers.js";

--- a/agent/src/android/general.ts
+++ b/agent/src/android/general.ts
@@ -1,3 +1,4 @@
+import Java from "frida-java-bridge";
 import { wrapJavaPerform } from "./lib/libjava.js";
 
 export const deoptimize = (): Promise<void> => {

--- a/agent/src/android/general.ts
+++ b/agent/src/android/general.ts
@@ -1,5 +1,7 @@
-import Java from "frida-java-bridge";
-import { wrapJavaPerform } from "./lib/libjava.js";
+import {
+  wrapJavaPerform,
+  Java
+} from "./lib/libjava.js";
 
 export const deoptimize = (): Promise<void> => {
   return wrapJavaPerform(() => {

--- a/agent/src/android/heap.ts
+++ b/agent/src/android/heap.ts
@@ -1,4 +1,3 @@
-import Java from "frida-java-bridge";
 import { colors as c } from "../lib/color.js";
 import {
   IHeapClassDictionary,
@@ -6,11 +5,15 @@ import {
   IJavaField,
   IHeapNormalised
 } from "./lib/interfaces.js";
-import { wrapJavaPerform } from "./lib/libjava.js";
-
+import {
+  wrapJavaPerform,
+  Java
+} from "./lib/libjava.js";
 export let handles: IHeapClassDictionary = {};
+import type { default as JavaTypes } from "frida-java-bridge";
 
-const getInstance = (hashcode: number): Java.Wrapper | null => {
+
+const getInstance = (hashcode: number): JavaTypes.Wrapper | null => {
   const matches: IHeapObject[] = [];
 
   // Search for this handle, and push the results to matches
@@ -113,7 +116,7 @@ export const fields = (handle: number): Promise<IJavaField[]> => {
 
     return clazz.class.getDeclaredFields().map((field: any): IJavaField => {
       const fieldName: string = field.getName();
-      const fieldInstance: Java.Wrapper = clazz.class.getDeclaredField(fieldName);
+      const fieldInstance: JavaTypes.Wrapper = clazz.class.getDeclaredField(fieldName);
       fieldInstance.setAccessible(true);
 
       let fieldValue = fieldInstance.get(clazz);

--- a/agent/src/android/heap.ts
+++ b/agent/src/android/heap.ts
@@ -1,3 +1,4 @@
+import Java from "frida-java-bridge";
 import { colors as c } from "../lib/color.js";
 import {
   IHeapClassDictionary,

--- a/agent/src/android/hooking.ts
+++ b/agent/src/android/hooking.ts
@@ -1,11 +1,11 @@
-import Java from "frida-java-bridge";
 import { colors as c } from "../lib/color.js";
 import * as jobs from "../lib/jobs.js";
 import { ICurrentActivityFragment } from "./lib/interfaces.js";
 import {
   getApplicationContext,
   R,
-  wrapJavaPerform
+  wrapJavaPerform,
+  Java
 } from "./lib/libjava.js";
 import {
   Activity,
@@ -17,6 +17,7 @@ import {
   Throwable,
   JavaMethodsOverloadsResult,
 } from "./lib/types.js";
+import type { default as JavaTypes } from "frida-java-bridge";
 
 enum PatternType {
   Regex = 'regex',
@@ -71,7 +72,7 @@ export const lazyWatchForPattern = (query: string, watch: boolean, dargs: boolea
 
   // This method loops over all enumerate matches and then calls watch
   // with the arguments specified in the parent function
-  const watchMatches = (matches: Java.EnumerateMethodsMatchGroup[]) => {
+  const watchMatches = (matches: JavaTypes.EnumerateMethodsMatchGroup[]) => {
     matches.forEach(match => {
       match.classes.forEach(_class => {
         _class.methods.forEach(_method => {
@@ -115,7 +116,7 @@ export const lazyWatchForPattern = (query: string, watch: boolean, dargs: boolea
   }, 1000 * 5);
 };
 
-export const javaEnumerate = (query: string): Promise<Java.EnumerateMethodsMatchGroup[]> => {
+export const javaEnumerate = (query: string): Promise<JavaTypes.EnumerateMethodsMatchGroup[]> => {
   // If the query is just a classname, strongarm it into a pattern.
   if (getPatternType(query) === PatternType.Klass) {
     query = `*${query}*!*`;
@@ -271,9 +272,9 @@ export const watch = (pattern: string, dargs: boolean, dbt: boolean, dret: boole
   jobs.add(job);
 
   return new Promise((resolve, reject) => {
-    javaEnumerate(pattern).then((matches: Java.EnumerateMethodsMatchGroup[]) => {
-      matches.forEach((match: Java.EnumerateMethodsMatchGroup) => {
-        match.classes.forEach((klass: Java.EnumerateMethodsMatchClass) => {
+    javaEnumerate(pattern).then((matches: JavaTypes.EnumerateMethodsMatchGroup[]) => {
+      matches.forEach((match: JavaTypes.EnumerateMethodsMatchGroup) => {
+        match.classes.forEach((klass: JavaTypes.EnumerateMethodsMatchClass) => {
           klass.methods.forEach(method => {
             // Only watch matched methods
             watchMethod(`${klass.name}.${method}`, job, dargs, dbt, dret);

--- a/agent/src/android/hooking.ts
+++ b/agent/src/android/hooking.ts
@@ -1,3 +1,4 @@
+import Java from "frida-java-bridge";
 import { colors as c } from "../lib/color.js";
 import * as jobs from "../lib/jobs.js";
 import { ICurrentActivityFragment } from "./lib/interfaces.js";

--- a/agent/src/android/intent.ts
+++ b/agent/src/android/intent.ts
@@ -1,3 +1,4 @@
+import Java from "frida-java-bridge";
 import { colors as c } from "../lib/color.js";
 import {
   getApplicationContext,

--- a/agent/src/android/intent.ts
+++ b/agent/src/android/intent.ts
@@ -1,13 +1,13 @@
-import Java from "frida-java-bridge";
 import { colors as c } from "../lib/color.js";
 import {
   getApplicationContext,
-  wrapJavaPerform
+  wrapJavaPerform,
+  Java
 } from "./lib/libjava.js";
 import { Intent, FridaOverload } from "./lib/types.js";
 import { analyseIntent } from "./lib/intentUtils.js";
 import * as jobs from "../lib/jobs.js";
-
+import type { default as JavaTypes } from "frida-java-bridge";
 
 // https://developer.android.com/reference/android/content/Intent.html#FLAG_ACTIVITY_NEW_TASK
 const FLAG_ACTIVITY_NEW_TASK = 0x10000000;
@@ -29,7 +29,7 @@ export const startActivity = (activityClass: string): Promise<void> => {
     const androidIntent: Intent = Java.use("android.content.Intent");
 
     // Get the Activity class's .class
-    const newActivity: Java.Wrapper = Java.use(activityClass).class;
+    const newActivity: JavaTypes.Wrapper = Java.use(activityClass).class;
     send(`Starting activity ${c.green(activityClass)}...`);
 
     // Init and launch the intent

--- a/agent/src/android/keystore.ts
+++ b/agent/src/android/keystore.ts
@@ -1,3 +1,4 @@
+import Java from "frida-java-bridge";
 import { colors as c } from "../lib/color.js";
 import {
   IKeyStoreDetail,

--- a/agent/src/android/keystore.ts
+++ b/agent/src/android/keystore.ts
@@ -1,10 +1,12 @@
-import Java from "frida-java-bridge";
 import { colors as c } from "../lib/color.js";
 import {
   IKeyStoreDetail,
   IKeyStoreEntry
 } from "./lib/interfaces.js";
-import { wrapJavaPerform } from "./lib/libjava.js";
+import { 
+  wrapJavaPerform, 
+  Java 
+} from "./lib/libjava.js";
 import {
   KeyFactory,
   KeyInfo,

--- a/agent/src/android/lib/intentUtils.ts
+++ b/agent/src/android/lib/intentUtils.ts
@@ -1,7 +1,7 @@
-import Java from "frida-java-bridge";
+import { Java } from "./libjava.js";
 import { colors as c } from "../../lib/color.js";
 
-export const analyseIntent = (methodName: string, intent: Java.Wrapper, backtrace: boolean = false): void => {
+export const analyseIntent = (methodName: string, intent: any, backtrace: boolean = false): void => {
   try {
     send(`\nAnalyzing Intent from: ${c.green(`${methodName}`)}`);
 

--- a/agent/src/android/lib/intentUtils.ts
+++ b/agent/src/android/lib/intentUtils.ts
@@ -1,3 +1,4 @@
+import Java from "frida-java-bridge";
 import { colors as c } from "../../lib/color.js";
 
 export const analyseIntent = (methodName: string, intent: Java.Wrapper, backtrace: boolean = false): void => {

--- a/agent/src/android/lib/interfaces.ts
+++ b/agent/src/android/lib/interfaces.ts
@@ -1,4 +1,4 @@
-import Java from "frida-java-bridge";
+import type { default as JavaTypes } from "frida-java-bridge";
 
 export interface IAndroidFilesystem {
   files: any;
@@ -30,7 +30,7 @@ export interface IHeapClassDictionary {
 
 export interface IHeapObject {
   hashcode: number;
-  instance: Java.Wrapper;
+  instance: JavaTypes.Wrapper;
 }
 
 export interface IHeapNormalised {

--- a/agent/src/android/lib/interfaces.ts
+++ b/agent/src/android/lib/interfaces.ts
@@ -1,3 +1,5 @@
+import Java from "frida-java-bridge";
+
 export interface IAndroidFilesystem {
   files: any;
   path: string;

--- a/agent/src/android/lib/libjava.ts
+++ b/agent/src/android/lib/libjava.ts
@@ -1,13 +1,16 @@
 import Java_bridge from "frida-java-bridge";
+import { colors as c } from "../../lib/color.js";
 
-let Java: any | undefined;
+let Java: typeof Java_bridge;
 // Compatibility with frida < 17
 if (globalThis.Java) {
-  console.error("Warning old version of Frida.")
-  Java = globalThis.Java
+  send(c.blackBright("Pre-v17 version of Frida detected. Attempting to use old bridge interface."))
+  Java = globalThis.Java   
 } else {
   Java = Java_bridge
 }
+
+export { Java }
 
 // all Java calls need to be wrapped in a Java.perform().
 // this helper just wraps that into a Promise that the

--- a/agent/src/android/lib/libjava.ts
+++ b/agent/src/android/lib/libjava.ts
@@ -1,3 +1,5 @@
+import Java from "frida-java-bridge";
+
 // all Java calls need to be wrapped in a Java.perform().
 // this helper just wraps that into a Promise that the
 // rpc export will sniff and resolve before returning

--- a/agent/src/android/lib/libjava.ts
+++ b/agent/src/android/lib/libjava.ts
@@ -1,4 +1,13 @@
-import Java from "frida-java-bridge";
+import Java_bridge from "frida-java-bridge";
+
+let Java: any | undefined;
+// Compatibility with frida < 17
+if (globalThis.Java) {
+  console.error("Warning old version of Frida.")
+  Java = globalThis.Java
+} else {
+  Java = Java_bridge
+}
 
 // all Java calls need to be wrapped in a Java.perform().
 // this helper just wraps that into a Promise that the

--- a/agent/src/android/pinning.ts
+++ b/agent/src/android/pinning.ts
@@ -1,3 +1,4 @@
+import Java from "frida-java-bridge";
 import { colors as c } from "../lib/color.js";
 import { qsend } from "../lib/helpers.js";
 import * as jobs from "../lib/jobs.js";

--- a/agent/src/android/pinning.ts
+++ b/agent/src/android/pinning.ts
@@ -1,8 +1,10 @@
-import Java from "frida-java-bridge";
 import { colors as c } from "../lib/color.js";
 import { qsend } from "../lib/helpers.js";
 import * as jobs from "../lib/jobs.js";
-import { wrapJavaPerform } from "./lib/libjava.js";
+import {
+  wrapJavaPerform,
+  Java
+} from "./lib/libjava.js";
 import {
   ArrayList,
   CertificatePinner,

--- a/agent/src/android/proxy.ts
+++ b/agent/src/android/proxy.ts
@@ -1,3 +1,4 @@
+import Java from "frida-java-bridge";
 import { wrapJavaPerform } from "./lib/libjava.js";
 import { colors as c } from "../lib/color.js";
 

--- a/agent/src/android/proxy.ts
+++ b/agent/src/android/proxy.ts
@@ -1,5 +1,7 @@
-import Java from "frida-java-bridge";
-import { wrapJavaPerform } from "./lib/libjava.js";
+import { 
+  wrapJavaPerform,
+  Java
+} from "./lib/libjava.js";
 import { colors as c } from "../lib/color.js";
 
 export const set = (host: string, port: string): Promise<void> => {

--- a/agent/src/android/root.ts
+++ b/agent/src/android/root.ts
@@ -1,7 +1,9 @@
-import Java from "frida-java-bridge";
 import { colors as c } from "../lib/color.js";
 import * as jobs from "../lib/jobs.js";
-import { wrapJavaPerform } from "./lib/libjava.js";
+import {
+  wrapJavaPerform,
+  Java
+} from "./lib/libjava.js";
 import {
   File,
   IOException,

--- a/agent/src/android/root.ts
+++ b/agent/src/android/root.ts
@@ -1,3 +1,4 @@
+import Java from "frida-java-bridge";
 import { colors as c } from "../lib/color.js";
 import * as jobs from "../lib/jobs.js";
 import { wrapJavaPerform } from "./lib/libjava.js";

--- a/agent/src/android/shell.ts
+++ b/agent/src/android/shell.ts
@@ -1,6 +1,8 @@
-import Java from "frida-java-bridge";
 import { IExecutedCommand } from "./lib/interfaces.js";
-import { wrapJavaPerform } from "./lib/libjava.js";
+import {
+  wrapJavaPerform,
+  Java
+} from "./lib/libjava.js";
 import {
   BufferedReader,
   InputStreamReader,

--- a/agent/src/android/shell.ts
+++ b/agent/src/android/shell.ts
@@ -1,3 +1,4 @@
+import Java from "frida-java-bridge";
 import { IExecutedCommand } from "./lib/interfaces.js";
 import { wrapJavaPerform } from "./lib/libjava.js";
 import {

--- a/agent/src/android/userinterface.ts
+++ b/agent/src/android/userinterface.ts
@@ -1,3 +1,4 @@
+import Java from "frida-java-bridge";
 import { colors as c } from "../lib/color.js";
 import { wrapJavaPerform } from "./lib/libjava.js";
 import {

--- a/agent/src/android/userinterface.ts
+++ b/agent/src/android/userinterface.ts
@@ -1,6 +1,8 @@
-import Java from "frida-java-bridge";
 import { colors as c } from "../lib/color.js";
-import { wrapJavaPerform } from "./lib/libjava.js";
+import {
+  wrapJavaPerform,
+  Java
+} from "./lib/libjava.js";
 import {
   Activity,
   ActivityClientRecord,

--- a/agent/src/generic/environment.ts
+++ b/agent/src/generic/environment.ts
@@ -1,8 +1,8 @@
-import Java from "frida-java-bridge";
-import ObjC from "frida-objc-bridge";
+import { ObjC } from "../ios/lib/libobjc.js";
 import {
   getApplicationContext,
-  wrapJavaPerform
+  wrapJavaPerform,
+  Java
 } from "../android/lib/libjava.js";
 import {
   NSSearchPaths,

--- a/agent/src/generic/environment.ts
+++ b/agent/src/generic/environment.ts
@@ -1,3 +1,5 @@
+import Java from "frida-java-bridge";
+import ObjC from "frida-objc-bridge";
 import {
   getApplicationContext,
   wrapJavaPerform

--- a/agent/src/generic/http.ts
+++ b/agent/src/generic/http.ts
@@ -40,62 +40,64 @@ const dirListingHTML = (pwd: string, path: string): string => {
 };
 
 export const start = (pwd: string, port: number = 9000): void => {
+  log(c.redBright(`httpServer module not currently available.`))
+
   if (httpServer) {
     log(c.redBright(`Server appears to already be running`));
     return;
   }
 
-  if (!pwd.endsWith("/")) {
-    pwd = pwd + "/";
-  }
-  log(`${c.blackBright(`Starting HTTP server in: ${pwd}`)}`);
-  servePath = pwd;
+  // if (!pwd.endsWith("/")) {
+  //   pwd = pwd + "/";
+  // }
+  // log(`${c.blackBright(`Starting HTTP server in: ${pwd}`)}`);
+  // servePath = pwd;
 
-  httpServer = httpLib.createServer((req, res) => {
-    if (req.method && req.url) {
-      log(`${c.greenBright(req.method)} ${req.url}`);
-    } else {
-      log(`${c.redBright('Missing URL or request method.')}`);
-      return;
-    }
+  // httpServer = httpLib.createServer((req, res) => {
+    // if (req.method && req.url) {
+    //   log(`${c.greenBright(req.method)} ${req.url}`);
+    // } else {
+    //   log(`${c.redBright('Missing URL or request method.')}`);
+    //   return;
+    // }
 
-    try {    
-      const parsedUrl = url.parse(req.url);  
-      const fileLocation = pwd + decodeURIComponent(parsedUrl.path);
+    // try {    
+    //   const parsedUrl = url.parse(req.url);  
+    //   const fileLocation = pwd + decodeURIComponent(parsedUrl.path);
       
-      if (fs.statSync(fileLocation).isDirectory()) {
-        res.end(dirListingHTML(pwd, parsedUrl.path));
-        return;
-      }
+    //   if (fs.statSync(fileLocation).isDirectory()) {
+    //     res.end(dirListingHTML(pwd, parsedUrl.path));
+    //     return;
+    //   }
 
-      res.setHeader("Content-type", "application/octet-stream");
+    //   res.setHeader("Content-type", "application/octet-stream");
 
-      // Check that we are not reading an empty file
-      if (fs.statSync(fileLocation).size !== 0) {
-        const file = fs.readFileSync(fileLocation);
-        res.write(file, 'utf-8')
-      }
-      res.end();
+    //   // Check that we are not reading an empty file
+    //   if (fs.statSync(fileLocation).size !== 0) {
+    //     const file = fs.readFileSync(fileLocation);
+    //     res.write(file, 'utf-8')
+    //   }
+    //   res.end();
         
-    } catch (error) {
-      if (error instanceof Error && error.message == "No such file or directory") {
-        res.statusCode = 404;
-        res.end("File not found")
-      } else {
-        if (error instanceof Error) {
-          log(c.redBright(`${error.stack}`));
-        } else {
-          log(c.redBright(`${error}`));
-        }
+    // } catch (error) {
+    //   if (error instanceof Error && error.message == "No such file or directory") {
+    //     res.statusCode = 404;
+    //     res.end("File not found")
+    //   } else {
+    //     if (error instanceof Error) {
+    //       log(c.redBright(`${error.stack}`));
+    //     } else {
+    //       log(c.redBright(`${error}`));
+    //     }
        
-        res.statusCode = 500;
-        res.end("Internal Server Error")
-      }
-    }
-  });
+    //     res.statusCode = 500;
+    //     res.end("Internal Server Error")
+    //   }
+    // }
+  // });
 
-  httpServer.listen(port);
-  listenPort = port;
+  // httpServer.listen(port);
+  // listenPort = port;
 };
 
 export const stop = (): void => {

--- a/agent/src/ios/binarycookies.ts
+++ b/agent/src/ios/binarycookies.ts
@@ -1,4 +1,4 @@
-import ObjC from "frida-objc-bridge";
+import { ObjC } from "../ios/lib/libobjc.js";
 import { IIosCookie } from "./lib/interfaces.js";
 import {
   NSArray,

--- a/agent/src/ios/binarycookies.ts
+++ b/agent/src/ios/binarycookies.ts
@@ -1,3 +1,4 @@
+import ObjC from "frida-objc-bridge";
 import { IIosCookie } from "./lib/interfaces.js";
 import {
   NSArray,

--- a/agent/src/ios/bundles.ts
+++ b/agent/src/ios/bundles.ts
@@ -1,3 +1,4 @@
+import ObjC from "frida-objc-bridge";
 import { BundleType } from "./lib/constants.js";
 import { IFramework } from "./lib/interfaces.js";
 import {

--- a/agent/src/ios/bundles.ts
+++ b/agent/src/ios/bundles.ts
@@ -1,4 +1,4 @@
-import ObjC from "frida-objc-bridge";
+import { ObjC } from "../ios/lib/libobjc.js";
 import { BundleType } from "./lib/constants.js";
 import { IFramework } from "./lib/interfaces.js";
 import {

--- a/agent/src/ios/credentialstorage.ts
+++ b/agent/src/ios/credentialstorage.ts
@@ -1,4 +1,4 @@
-import ObjC from "frida-objc-bridge";
+import { ObjC } from "../ios/lib/libobjc.js";
 import { ICredential } from "./lib/interfaces.js";
 import {
   NSArray,

--- a/agent/src/ios/credentialstorage.ts
+++ b/agent/src/ios/credentialstorage.ts
@@ -1,3 +1,4 @@
+import ObjC from "frida-objc-bridge";
 import { ICredential } from "./lib/interfaces.js";
 import {
   NSArray,

--- a/agent/src/ios/crypto.ts
+++ b/agent/src/ios/crypto.ts
@@ -69,7 +69,7 @@ let dataOutBytes: string = "";
 const secrandomcopybytes = (ident: number): InvocationListener => {
   const hook = "SecRandomCopyBytes";
   return Interceptor.attach(
-    Module.getExportByName(null, hook), {
+    Module.getGlobalExportByName(hook), {
     onEnter(args) {
 
       this.secrandomcopybytes = {};
@@ -89,7 +89,7 @@ const secrandomcopybytes = (ident: number): InvocationListener => {
 const cckeyderivationpbkdf = (ident: number): InvocationListener => {
   const hook = "CCKeyDerivationPBKDF";
   return Interceptor.attach(
-    Module.getExportByName(null, hook), {
+    Module.getGlobalExportByName(hook), {
     onEnter(args) {
 
       this.cckeyderivationpbkdf = {};
@@ -143,7 +143,7 @@ const cckeyderivationpbkdf = (ident: number): InvocationListener => {
 const cccrypt = (ident: number): InvocationListener => {
   const hook = "CCCrypt";
   return Interceptor.attach(
-    Module.getExportByName(null, hook), {
+    Module.getGlobalExportByName(hook), {
     onEnter(args) {
 
       this.cccrpyt = {};
@@ -214,7 +214,7 @@ const cccrypt = (ident: number): InvocationListener => {
 const cccryptorcreate = (ident: number): InvocationListener => {
   const hook = "CCCryptorCreate";
   return Interceptor.attach(
-    Module.getExportByName(null, hook), {
+    Module.getGlobalExportByName(hook), {
     onEnter(args) {
 
       this.cccryptorcreate = {};
@@ -260,7 +260,7 @@ const cccryptorcreate = (ident: number): InvocationListener => {
 const cccryptorupdate = (ident: number): InvocationListener => {
   const hook = "CCCryptorUpdate";
   return Interceptor.attach(
-    Module.getExportByName(null, hook), {
+    Module.getGlobalExportByName(hook), {
     onEnter(args) {
       this.cccryptorupdate = {};
 
@@ -303,7 +303,7 @@ const cccryptorupdate = (ident: number): InvocationListener => {
 const cccryptorfinal = (ident: number): InvocationListener => {
   const hook = "CCCryptorFinal";
   return Interceptor.attach(
-    Module.getExportByName(null, hook), {
+    Module.getGlobalExportByName(hook), {
     onEnter(args) {
 
       this.cccryptorfinal = {};

--- a/agent/src/ios/crypto.ts
+++ b/agent/src/ios/crypto.ts
@@ -66,6 +66,13 @@ let alg = 0;
 // append the final block from CCCryptorFinal
 let dataOutBytes: string = "";
 
+// Compatibility with frida < 16.7
+if (!Module.getGlobalExportByName) {
+  Module.getGlobalExportByName = function(name) {
+    return Module['getExportByName'](null, name);
+  }
+}
+
 const secrandomcopybytes = (ident: number): InvocationListener => {
   const hook = "SecRandomCopyBytes";
   return Interceptor.attach(

--- a/agent/src/ios/filesystem.ts
+++ b/agent/src/ios/filesystem.ts
@@ -1,3 +1,4 @@
+import ObjC from "frida-objc-bridge";
 import * as fs from "frida-fs";
 import { Buffer } from "buffer";
 import { hexStringToBytes } from "../lib/helpers.js";

--- a/agent/src/ios/filesystem.ts
+++ b/agent/src/ios/filesystem.ts
@@ -1,4 +1,4 @@
-import ObjC from "frida-objc-bridge";
+import { ObjC } from "../ios/lib/libobjc.js";
 import * as fs from "frida-fs";
 import { Buffer } from "buffer";
 import { hexStringToBytes } from "../lib/helpers.js";

--- a/agent/src/ios/heap.ts
+++ b/agent/src/ios/heap.ts
@@ -1,3 +1,4 @@
+import ObjC from "frida-objc-bridge";
 import { colors as c } from "../lib/color.js";
 import { bytesToUTF8 } from "./lib/helpers.js";
 import { IHeapObject } from "./lib/interfaces.js";

--- a/agent/src/ios/heap.ts
+++ b/agent/src/ios/heap.ts
@@ -1,16 +1,17 @@
-import ObjC from "frida-objc-bridge";
+import { ObjC } from "../ios/lib/libobjc.js";
+import type { default as ObjCTypes } from "frida-objc-bridge";
 import { colors as c } from "../lib/color.js";
 import { bytesToUTF8 } from "./lib/helpers.js";
 import { IHeapObject } from "./lib/interfaces.js";
 
 
-const enumerateInstances = (clazz: string): ObjC.Object[] => {
+const enumerateInstances = (clazz: string): ObjCTypes.Object[] => {
   if (!ObjC.classes.hasOwnProperty(clazz)) {
     c.log(`Unknown Objective-C class: ${c.redBright(clazz)}`);
     return [];
   }
 
-  const specifier: ObjC.DetailedChooseSpecifier = {
+  const specifier: ObjCTypes.DetailedChooseSpecifier = {
     class: ObjC.classes[clazz],
     subclasses: true,  // don't skip subclasses
   };
@@ -41,7 +42,7 @@ export const getInstances = (clazz: string): IHeapObject[] => {
   return instances;
 };
 
-const resolvePointer = (pointer: string): ObjC.Object => {
+const resolvePointer = (pointer: string): ObjCTypes.Object => {
   const o = new ObjC.Object(new NativePointer(pointer));
   c.log(`${c.blackBright(`Pointer ` + pointer + ` is to class `)}${c.greenBright(o.$className)}`);
 

--- a/agent/src/ios/hooking.ts
+++ b/agent/src/ios/hooking.ts
@@ -1,3 +1,4 @@
+import ObjC from "frida-objc-bridge";
 import { colors as c } from "../lib/color.js";
 import * as jobs from "../lib/jobs.js";
 

--- a/agent/src/ios/hooking.ts
+++ b/agent/src/ios/hooking.ts
@@ -1,4 +1,4 @@
-import ObjC from "frida-objc-bridge";
+import { ObjC } from "../ios/lib/libobjc.js";
 import { colors as c } from "../lib/color.js";
 import * as jobs from "../lib/jobs.js";
 

--- a/agent/src/ios/jailbreak.ts
+++ b/agent/src/ios/jailbreak.ts
@@ -1,4 +1,4 @@
-import ObjC from "frida-objc-bridge";
+import { ObjC } from "../ios/lib/libobjc.js";
 import { colors as c } from "../lib/color.js";
 import * as jobs from "../lib/jobs.js";
 

--- a/agent/src/ios/jailbreak.ts
+++ b/agent/src/ios/jailbreak.ts
@@ -114,11 +114,19 @@ const fileExistsAtPath = (success: boolean, ident: number): InvocationListener =
 
 
 // toggles replies to fopen: for the paths in jailbreakPaths
-const fopen = (success: boolean, ident: number): InvocationListener => {
+const fopen = (success: boolean, ident: number): InvocationListener | null => {
+
+  // Compatibility with frida < 16.7
+  if (!Module.findGlobalExportByName) {
+    Module.findGlobalExportByName = function(name) {
+      return Module['findExportByName'](null, name);
+    }
+  }
+
   const fopen_addr = Module.findGlobalExportByName("fopen");
   if (!fopen_addr) {
     send(c.red(`fopen function not found!`));
-    return new InvocationListener(); 
+    return null; 
   }
 
   return Interceptor.attach(fopen_addr, {
@@ -237,15 +245,14 @@ const canOpenURL = (success: boolean, ident: number): InvocationListener => {
 };
 
 
-const libSystemBFork = (success: boolean, ident: number): InvocationListener => {
+const libSystemBFork = (success: boolean, ident: number): InvocationListener | null => {
   // Hook fork() in libSystem.B.dylib and return 0
   // TODO: Hook vfork
   const libSystemBdylib = Process.findModuleByName("libSystem.B.dylib");
 
-  if (!libSystemBdylib) {
-    return new InvocationListener();
-  }
+  if (!libSystemBdylib) return null;
   const libSystemBdylibFork = libSystemBdylib.findExportByName("fork");
+  if (!libSystemBdylibFork) return null;
 
   return Interceptor.attach(libSystemBdylibFork, {
     onLeave(retval) {
@@ -284,9 +291,9 @@ const libSystemBFork = (success: boolean, ident: number): InvocationListener => 
 };
 
 // ref: https://www.ayrx.me/gantix-jailmonkey-root-detection-bypass/
-const jailMonkeyBypass = (success: boolean, ident: number): InvocationListener => {
+const jailMonkeyBypass = (success: boolean, ident: number): InvocationListener | null => {
   const JailMonkeyClass = ObjC.classes.JailMonkey;
-  if (JailMonkeyClass === undefined) return new InvocationListener();
+  if (JailMonkeyClass === undefined) return null;
 
   return Interceptor.attach(JailMonkeyClass["- isJailBroken"].implementation, {
     onLeave(retval) {

--- a/agent/src/ios/keychain.ts
+++ b/agent/src/ios/keychain.ts
@@ -1,6 +1,5 @@
 // dumps all of the keychain items available to the current
 // application.
-import ObjC from "frida-objc-bridge";
 import { colors as c } from "../lib/color.js";
 import { reverseEnumLookup } from "../lib/helpers.js";
 import {
@@ -16,7 +15,10 @@ import {
   IKeychainData,
   IKeychainItem
 } from "./lib/interfaces.js";
-import { libObjc } from "./lib/libobjc.js";
+import { 
+  libObjc, 
+  ObjC 
+} from "./lib/libobjc.js";
 import {
   NSDictionary,
   NSMutableDictionary as NSMutableDictionaryType,

--- a/agent/src/ios/keychain.ts
+++ b/agent/src/ios/keychain.ts
@@ -1,5 +1,6 @@
 // dumps all of the keychain items available to the current
 // application.
+import ObjC from "frida-objc-bridge";
 import { colors as c } from "../lib/color.js";
 import { reverseEnumLookup } from "../lib/helpers.js";
 import {

--- a/agent/src/ios/lib/helpers.ts
+++ b/agent/src/ios/lib/helpers.ts
@@ -1,3 +1,4 @@
+import ObjC from "frida-objc-bridge";
 import { NSUTF8StringEncoding } from "./constants.js";
 import {
   NSBundle,

--- a/agent/src/ios/lib/helpers.ts
+++ b/agent/src/ios/lib/helpers.ts
@@ -1,4 +1,5 @@
-import ObjC from "frida-objc-bridge";
+import { ObjC } from "./libobjc.js";
+import type { default as ObjCTypes } from "frida-objc-bridge";
 import { NSUTF8StringEncoding } from "./constants.js";
 import {
   NSBundle,
@@ -9,7 +10,7 @@ import {
 
 // Attempt to unarchive data. Returning a string of `` indicates that the
 // unarchiving failed.
-export const unArchiveDataAndGetString = (data: ObjC.Object | any): string => {
+export const unArchiveDataAndGetString = (data: ObjCTypes.Object | any): string => {
 
   try {
 
@@ -56,7 +57,7 @@ export const smartDataToString = (raw: any): string => {
 
   try {
 
-    const dataObject: ObjC.Object | any = new ObjC.Object(raw);
+    const dataObject: ObjCTypes.Object | any = new ObjC.Object(raw);
 
     switch (dataObject.$className) {
       case "__NSCFData":

--- a/agent/src/ios/lib/libobjc.ts
+++ b/agent/src/ios/lib/libobjc.ts
@@ -1,3 +1,15 @@
+import ObjC_bridge from "frida-objc-bridge";
+
+let ObjC: typeof ObjC_bridge;
+// Compatibility with frida < 17
+if (globalThis.ObjC) { 
+  ObjC = globalThis.Java
+} else {
+  ObjC = ObjC_bridge
+}
+
+export { ObjC }
+
 const nativeExports: any = {
   // iOS keychain methods
   SecAccessControlGetConstraints: {

--- a/agent/src/ios/lib/libobjc.ts
+++ b/agent/src/ios/lib/libobjc.ts
@@ -115,7 +115,7 @@ export const libObjc = new Proxy(api, {
     if (target[key] === null) {
       const mod = Process.findModuleByName(nativeExports[key].moduleName)
       var tgt = new NativePointer(0x00);
-      if (!mod) {
+      if (mod != null) {
         tgt = mod.findExportByName(nativeExports[key].exportName) || new NativePointer(0x00);
       }
      

--- a/agent/src/ios/lib/libobjc.ts
+++ b/agent/src/ios/lib/libobjc.ts
@@ -113,10 +113,13 @@ export const libObjc = new Proxy(api, {
   get: (target, key) => {
 
     if (target[key] === null) {
-
-      const f = Module.findExportByName(
-        nativeExports[key].moduleName, nativeExports[key].exportName) || new NativePointer(0x00);
-      target[key] = new NativeFunction(f,
+      const mod = Process.findModuleByName(nativeExports[key].moduleName)
+      var tgt = new NativePointer(0x00);
+      if (!mod) {
+        tgt = mod.findExportByName(nativeExports[key].exportName) || new NativePointer(0x00);
+      }
+     
+      target[key] = new NativeFunction(tgt,
         nativeExports[key].retType, nativeExports[key].argTypes);
     }
 

--- a/agent/src/ios/lib/types.ts
+++ b/agent/src/ios/lib/types.ts
@@ -1,3 +1,5 @@
+import ObjC from "frida-objc-bridge";
+
 export type NSDictionary = ObjC.Object | any;
 export type NSMutableDictionary = ObjC.Object | any;
 export type NSString = ObjC.Object | any;

--- a/agent/src/ios/lib/types.ts
+++ b/agent/src/ios/lib/types.ts
@@ -1,15 +1,15 @@
-import ObjC from "frida-objc-bridge";
+import type { default as ObjCTypes } from "frida-objc-bridge";
 
-export type NSDictionary = ObjC.Object | any;
-export type NSMutableDictionary = ObjC.Object | any;
-export type NSString = ObjC.Object | any;
-export type NSFileManager = ObjC.Object | any;
-export type NSBundle = ObjC.Object | any;
-export type NSUserDefaults = ObjC.Object | any;
-export type NSHTTPCookieStorage = ObjC.Object | any;
-export type NSURLCredentialStorage = ObjC.Object | any;
-export type NSArray = ObjC.Object | any;
-export type NSData = ObjC.Object | any;
+export type NSDictionary = ObjCTypes.Object | any;
+export type NSMutableDictionary = ObjCTypes.Object | any;
+export type NSString = ObjCTypes.Object | any;
+export type NSFileManager = ObjCTypes.Object | any;
+export type NSBundle = ObjCTypes.Object | any;
+export type NSUserDefaults = ObjCTypes.Object | any;
+export type NSHTTPCookieStorage = ObjCTypes.Object | any;
+export type NSURLCredentialStorage = ObjCTypes.Object | any;
+export type NSArray = ObjCTypes.Object | any;
+export type NSData = ObjCTypes.Object | any;
 
 export type CFDictionaryRef = any;
 export type CFTypeRef = any;

--- a/agent/src/ios/nsuserdefaults.ts
+++ b/agent/src/ios/nsuserdefaults.ts
@@ -1,3 +1,4 @@
+import ObjC from "frida-objc-bridge";
 import {
   NSDictionary,
   NSUserDefaults

--- a/agent/src/ios/nsuserdefaults.ts
+++ b/agent/src/ios/nsuserdefaults.ts
@@ -1,4 +1,4 @@
-import ObjC from "frida-objc-bridge";
+import { ObjC } from "../ios/lib/libobjc.js";
 import {
   NSDictionary,
   NSUserDefaults

--- a/agent/src/ios/pasteboard.ts
+++ b/agent/src/ios/pasteboard.ts
@@ -1,4 +1,4 @@
-import ObjC from "frida-objc-bridge";
+import { ObjC } from "../ios/lib/libobjc.js";
 import { colors as c } from "../lib/color.js";
 
 

--- a/agent/src/ios/pasteboard.ts
+++ b/agent/src/ios/pasteboard.ts
@@ -1,3 +1,4 @@
+import ObjC from "frida-objc-bridge";
 import { colors as c } from "../lib/color.js";
 
 

--- a/agent/src/ios/pinning.ts
+++ b/agent/src/ios/pinning.ts
@@ -1,3 +1,4 @@
+import ObjC from "frida-objc-bridge";
 import { colors as c } from "../lib/color.js";
 import { qsend } from "../lib/helpers.js";
 import * as jobs from "../lib/jobs.js";

--- a/agent/src/ios/pinning.ts
+++ b/agent/src/ios/pinning.ts
@@ -138,7 +138,7 @@ const afNetworking = (ident: number): InvocationListener[] => {
   });
 
   // +[AFSecurityPolicy policyWithPinningMode:withPinnedCertificates:]
-  const policyWithPinningModewithPinnedCertificates: InvocationListener =
+  const policyWithPinningModewithPinnedCertificates: InvocationListener | null =
     (AFSecurityPolicy["+ policyWithPinningMode:withPinnedCertificates:"]) ? Interceptor.attach(
       AFSecurityPolicy["+ policyWithPinningMode:withPinnedCertificates:"].implementation, {
       onEnter(args) {
@@ -171,7 +171,7 @@ const afNetworking = (ident: number): InvocationListener[] => {
     setSSLPinningmode,
     setAllowInvalidCertificates,
     policyWithPinningMode,
-    policyWithPinningModewithPinnedCertificates,
+    ...(policyWithPinningModewithPinnedCertificates ? [policyWithPinningModewithPinnedCertificates] : []),
   ];
 };
 
@@ -251,7 +251,7 @@ const nsUrlSession = (ident: number): InvocationListener[] => {
 };
 
 // TrustKit
-const trustKit = (ident: number): InvocationListener => {
+const trustKit = (ident: number): InvocationListener | null => {
   // https://github.com/datatheorem/TrustKit/blob/
   //  71878dce8c761fc226fecc5dbb6e86fbedaee05e/TrustKit/TSKPinningValidator.m#L84
   if (!ObjC.classes.TSKPinningValidator) {
@@ -282,7 +282,7 @@ const trustKit = (ident: number): InvocationListener => {
   });
 };
 
-const cordovaCustomURLConnectionDelegate = (ident: number): InvocationListener => {
+const cordovaCustomURLConnectionDelegate = (ident: number): InvocationListener | null => {
   // https://github.com/EddyVerbruggen/SSLCertificateChecker-PhoneGap-Plugin/blob/
   //  67634bfdf4a31bb09b301db40f8f27fbd8818f61/src/ios/SSLCertificateChecker.m#L109-L116
   if (!ObjC.classes.CustomURLConnectionDelegate) {
@@ -409,7 +409,7 @@ const tlsHelperCreatePeerTrust = (ident: number): NativePointerValue => {
 };
 
 // nw_tls_create_peer_trust
-const nwTlsCreatePeerTrust = (ident: number): InvocationListener => {
+const nwTlsCreatePeerTrust = (ident: number): InvocationListener | null => {
   const peerTrust = libObjc.nw_tls_create_peer_trust;
 
   if (peerTrust.isNull()) {

--- a/agent/src/ios/pinning.ts
+++ b/agent/src/ios/pinning.ts
@@ -1,8 +1,11 @@
-import ObjC from "frida-objc-bridge";
 import { colors as c } from "../lib/color.js";
 import { qsend } from "../lib/helpers.js";
 import * as jobs from "../lib/jobs.js";
-import { libObjc } from "./lib/libobjc.js";
+import { 
+  libObjc, 
+  ObjC 
+} from "./lib/libobjc.js";
+import type { default as ObjCTypes } from "frida-objc-bridge";
 
 // These hooks attempt many ways to kill SSL pinning and certificate
 // validations. The first sections search for common libraries and
@@ -176,7 +179,7 @@ const afNetworking = (ident: number): InvocationListener[] => {
 };
 
 const nsUrlSession = (ident: number): InvocationListener[] => {
-  const NSURLCredential: ObjC.Object = ObjC.classes.NSURLCredential;
+  const NSURLCredential: ObjCTypes.Object = ObjC.classes.NSURLCredential;
   const resolver = new ApiResolver("objc");
   // - [NSURLSession URLSession:didReceiveChallenge:completionHandler:]
   const search: ApiResolverMatch[] = resolver.enumerateMatches(

--- a/agent/src/ios/plist.ts
+++ b/agent/src/ios/plist.ts
@@ -1,4 +1,4 @@
-import ObjC from "frida-objc-bridge";
+import { ObjC } from "../ios/lib/libobjc.js";
 import { NSMutableDictionary } from "./lib/types.js";
 
 

--- a/agent/src/ios/plist.ts
+++ b/agent/src/ios/plist.ts
@@ -1,3 +1,4 @@
+import ObjC from "frida-objc-bridge";
 import { NSMutableDictionary } from "./lib/types.js";
 
 

--- a/agent/src/ios/userinterface.ts
+++ b/agent/src/ios/userinterface.ts
@@ -1,4 +1,5 @@
 // tslint:disable-next-line:no-var-requires
+import ObjC from "frida-objc-bridge";
 import screenshot from "frida-screenshot";
 import { colors as c } from "../lib/color.js";
 import * as jobs from "../lib/jobs.js";

--- a/agent/src/ios/userinterface.ts
+++ b/agent/src/ios/userinterface.ts
@@ -1,5 +1,6 @@
 // tslint:disable-next-line:no-var-requires
-import ObjC from "frida-objc-bridge";
+import { ObjC } from "../ios/lib/libobjc.js";
+import type { default as ObjCTypes } from "frida-objc-bridge";
 import screenshot from "frida-screenshot";
 import { colors as c } from "../lib/color.js";
 import * as jobs from "../lib/jobs.js";
@@ -20,7 +21,7 @@ export const alert = (message: string): void => {
 
   // Defining a Block that will be passed as handler parameter
   // to +[UIAlertAction actionWithTitle:style:handler:]
-  const handler: ObjC.Block = new ObjC.Block({
+  const handler = new ObjC.Block({
     argTypes: ["object"],
     implementation: () => { return; },
     retType: "void",
@@ -30,11 +31,11 @@ export const alert = (message: string): void => {
   ObjC.schedule(ObjC.mainQueue, () => {
 
     // Using integer numerals for preferredStyle which is of type enum UIAlertControllerStyle
-    const alertController: ObjC.Object = UIAlertController.alertControllerWithTitle_message_preferredStyle_(
+    const alertController: ObjCTypes.Object = UIAlertController.alertControllerWithTitle_message_preferredStyle_(
       "Alert", message, 1);
 
     // Again using integer numeral for style parameter that is enum
-    const okButton: ObjC.Object = UIAlertAction.actionWithTitle_style_handler_("OK", 0, handler);
+    const okButton: ObjCTypes.Object = UIAlertAction.actionWithTitle_style_handler_("OK", 0, handler);
     alertController.addAction_(okButton);
 
     // Instead of using `ObjC.choose()` and looking for UIViewController instances

--- a/agent/src/rpc/android.ts
+++ b/agent/src/rpc/android.ts
@@ -1,4 +1,4 @@
-import Java from "frida-java-bridge";
+import type { default as JavaTypes } from "frida-java-bridge";
 import * as clipboard from "../android/clipboard.js";
 import * as androidfilesystem from "../android/filesystem.js";
 import * as heap from "../android/heap.js";
@@ -58,7 +58,7 @@ export const android = {
     hooking.setReturnValue(fqClazz, filterOverload, ret),
   androidHookingWatch: (pattern: string, watchArgs: boolean, watchBacktrace: boolean, watchRet: boolean): Promise<void> =>
     hooking.watch(pattern, watchArgs, watchBacktrace, watchRet),
-  androidHookingEnumerate: (query: string): Promise<Java.EnumerateMethodsMatchGroup[]> => hooking.javaEnumerate(query),
+  androidHookingEnumerate: (query: string): Promise<JavaTypes.EnumerateMethodsMatchGroup[]> => hooking.javaEnumerate(query),
   androidHookingLazyWatchForPattern: (query: string, watch: boolean, dargs: boolean, dret: boolean, dbt: boolean): void => hooking.lazyWatchForPattern(query, watch, dargs, dret, dbt),
 
   // android heap methods

--- a/agent/src/rpc/android.ts
+++ b/agent/src/rpc/android.ts
@@ -1,3 +1,4 @@
+import Java from "frida-java-bridge";
 import * as clipboard from "../android/clipboard.js";
 import * as androidfilesystem from "../android/filesystem.js";
 import * as heap from "../android/heap.js";

--- a/agent/tsconfig.json
+++ b/agent/tsconfig.json
@@ -8,7 +8,6 @@
     "module": "Node16",
     "esModuleInterop": true,
     "noImplicitAny": false,
-    "moduleResolution": "node16",
     "strictNullChecks": false
   }
 }

--- a/objection/commands/mobile_packages.py
+++ b/objection/commands/mobile_packages.py
@@ -3,7 +3,7 @@ import shutil
 
 import click
 import delegator
-from pkg_resources import parse_version
+from packaging.version import Version
 
 from ..utils.patchers.android import AndroidGadget, AndroidPatcher
 from ..utils.patchers.github import Github
@@ -49,7 +49,7 @@ def patch_ios_ipa(source: str, codesign_signature: str, provision_file: str, bin
 
     # check if the local version needs updating. this can be either because
     # the version is outdated or we simply don't have the gadget yet
-    if parse_version(github_version) != parse_version(local_version) or not ios_gadget.gadget_exists():
+    if Version(github_version) != Version(local_version) or not ios_gadget.gadget_exists():
         # download!
         click.secho('Remote FridaGadget version is v{0}, local is v{1}. Downloading...'.format(
             github_version, local_version), fg='green')
@@ -167,7 +167,7 @@ def patch_android_apk(source: str, architecture: str, pause: bool, skip_cleanup:
     # check if the local version needs updating. this can be either because
     # the version is outdated or we simply don't have the gadget yet, or, we want
     # a very specific version
-    if parse_version(github_version) != parse_version(local_version) or not android_gadget.gadget_exists():
+    if Version(github_version) != Version(local_version) or not android_gadget.gadget_exists():
         # download!
         click.secho('Remote FridaGadget version is v{0}, local is v{1}. Downloading...'.format(
             github_version, local_version), fg='green')

--- a/objection/console/cli.py
+++ b/objection/console/cli.py
@@ -40,11 +40,12 @@ def get_agent() -> Agent:
 @click.option('--network', '-N', is_flag=True, help='Connect using a network connection instead of USB.',
               show_default=True)
 @click.option('--host', '-h', default='127.0.0.1', show_default=True)
-@click.option('--port', '-p', required=False, default=27042, show_default=True)
+@click.option('--port', '-P', required=False, default=27042, show_default=True)
 @click.option('--api-host', '-ah', default='127.0.0.1', show_default=True)
 @click.option('--api-port', '-ap', required=False, default=8888, show_default=True)
 @click.option('--name', '-n', required=False,
               help='Name or bundle identifier to attach to.', show_default=True)
+@click.option('--gadget', '-g', is_eager=True, hidden=True, deprecated="Please use '-n' or '--name' instead")
 @click.option('--serial', '-S', required=False, default=None, help='A device serial to connect to.')
 @click.option('--debug', '-d', required=False, default=False, is_flag=True,
               help='Enable debug mode with verbose output.')
@@ -54,7 +55,7 @@ def get_agent() -> Agent:
 @click.option('--debugger', required=False, default=False, is_flag=True, help='Enable the Chrome debug port.')
 @click.option('--uid', required=False, default=None, help='Specify the uid to run as (Android only).')
 def cli(network: bool, host: str, port: int, api_host: str, api_port: int,
-        name: str, serial: str, debug: bool, spawn: bool, no_pause: bool, 
+        name: str, gadget: str, serial: str, debug: bool, spawn: bool, no_pause: bool,
         foremost: bool, debugger: bool, uid: int) -> None:
     """
         \b
@@ -82,6 +83,10 @@ def cli(network: bool, host: str, port: int, api_host: str, api_port: int,
     # set api parameters
     app_state.api_host = api_host
     app_state.api_port = api_port
+
+    # Backwards compatibility
+    if gadget is not None:
+        name = gadget
 
     state_connection.name = name
     state_connection.spawn = spawn
@@ -179,6 +184,33 @@ def start(plugin_folder: str, quiet: bool, startup_command: str, file_commands, 
     # drop into the repl
     repl.run(quiet=quiet)
 
+# Some ugly backwards compatibility
+@cli.command(deprecated="Use 'objection start' instead of 'objection explore'")
+@click.option('--plugin-folder', '-P', required=False, default=None, help='The folder to load plugins from.')
+@click.option('--quiet', '-q', required=False, default=False, is_flag=True)
+@click.option('--startup-command', '-s', required=False, multiple=True,
+              help='A command to run before the repl polls the device for information.')
+@click.option('--file-commands', '-c', required=False, type=click.File('r'),
+              help=('A file containing objection commands, separated by a '
+                    'newline, that will run before the repl polls the device for information.'))
+@click.option('--startup-script', '-S', required=False, type=click.File('r'),
+              help='A script to import and run before the repl polls the device for information.')
+@click.option('--enable-api', '-a', required=False, default=False, is_flag=True,
+              help='Start the objection API server.')
+def explore(plugin_folder: str, quiet: bool, startup_command: str, file_commands, startup_script: click.File,
+            enable_api: bool) -> None:
+    """
+        Deprecated: Use 'start' instead.
+    """
+    # Call the start command's callback directly
+    ctx = click.get_current_context()
+    ctx.invoke(start,
+               plugin_folder=plugin_folder,
+               quiet=quiet,
+               startup_command=startup_command,
+               file_commands=file_commands,
+               startup_script=startup_script,
+               enable_api=enable_api)
 
 @cli.command()
 @click.option('--hook-debug', '-d', required=False, default=False, is_flag=True,

--- a/objection/console/commands.py
+++ b/objection/console/commands.py
@@ -139,23 +139,23 @@ COMMANDS = {
 
             # http file server
 
-            'http': {
-                'meta': 'Work with an on device HTTP file server',
-                'commands': {
-                    'start': {
-                        'meta': 'Start\'s an HTTP server in the current working directory',
-                        'exec': http.start
-                    },
-                    'status': {
-                        'meta': 'Get the status of the HTTP server',
-                        'exec': http.status
-                    },
-                    'stop': {
-                        'meta': 'Stop\'s a running HTTP server',
-                        'exec': http.stop
-                    }
-                }
-            },
+            # 'http': {
+            #     'meta': 'Work with an on device HTTP file server',
+            #     'commands': {
+            #         'start': {
+            #             'meta': 'Start\'s an HTTP server in the current working directory',
+            #             'exec': http.start
+            #         },
+            #         'status': {
+            #             'meta': 'Get the status of the HTTP server',
+            #             'exec': http.status
+            #         },
+            #         'stop': {
+            #             'meta': 'Stop\'s a running HTTP server',
+            #             'exec': http.stop
+            #         }
+            #     }
+            # },
         }
     },
 

--- a/objection/utils/helpers.py
+++ b/objection/utils/helpers.py
@@ -2,11 +2,9 @@ import re
 import shlex
 
 import click
-from pkg_resources import parse_version
-
+from packaging.version import Version
 from ..state.app import app_state
 from ..state.device import device_state, Ios, Android
-from ..state.jobs import job_manager_state
 
 
 def debug_print(message: str) -> None:
@@ -141,7 +139,7 @@ def warn_about_older_operating_systems() -> None:
 
     # android & ios version warnings
     if device_state.platform == Android and (
-            parse_version(device_state.version) < parse_version(android_supported)):
+            Version(device_state.version) < Version(android_supported)):
         click.secho('Warning: You appear to be running Android {0} which may result in '
                     'some hooks failing.\nIt is recommended to use at least an Android '
                     'version {1} device with objection.'.format(device_state.version, android_supported),
@@ -149,7 +147,7 @@ def warn_about_older_operating_systems() -> None:
 
     # android & ios version warnings
     if device_state.platform == Ios and (
-            parse_version(device_state.version) < parse_version(ios_supported)):
+            Version(device_state.version) < Version(ios_supported)):
         click.secho('Warning: You appear to be running iOS {0} which may result in '
                     'some hooks failing.\nIt is recommended to use at least an iOS '
                     'version {1} device with objection.'.format(device_state.version, ios_supported),

--- a/objection/utils/patchers/android.py
+++ b/objection/utils/patchers/android.py
@@ -192,7 +192,7 @@ class AndroidPatcher(BasePlatformPatcher):
             'installation': 'apt install apksigner (Kali Linux)'
         },
         'apktool': {
-            'installation': 'apt install apktool (Kali Linux)'
+            'installation': 'Install from https://apktool.org/docs/install'
         },
         'zipalign': {
             'installation': 'apt install zipalign (Kali Linux)'
@@ -223,7 +223,7 @@ class AndroidPatcher(BasePlatformPatcher):
             :return:bool
         """
 
-        min_version = '2.4.1'  # the version of apktool we require
+        min_version = '2.6.0'  # the version of apktool we require
 
         o = delegator.run(self.list2cmdline([
             self.required_commands['apktool']['location'],

--- a/objection/utils/update_checker.py
+++ b/objection/utils/update_checker.py
@@ -4,7 +4,7 @@ from datetime import datetime, timedelta
 
 import click
 import requests
-from pkg_resources import parse_version
+from packaging.version import Version
 
 from ..__init__ import __version__
 
@@ -63,7 +63,7 @@ def notify_newer_version() -> None:
 
     cache_version = cached_version_data()['remote_version']
 
-    if parse_version(cache_version) > parse_version(__version__):
+    if Version(cache_version) > Version(__version__):
         click.secho('\n\nA newer version of objection is available!', fg='green')
         click.secho('You have v{0} and v{1} is ready for download.\n'.format(
             __version__, cache_version), fg='green')

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ Flask>=3.0.0
 Pygments>=2.0.0
 litecli>=1.3.0
 setuptools>=70.0.0
+packaging>=23.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,11 +1,11 @@
 frida>=16.0.0
 frida-tools>=10.0.0
-prompt-toolkit>=3.0.3,<4.0.0
-click
+prompt-toolkit>=3.0.30,<4.0.0
+click>=8.2.0
 tabulate
-semver>=2,<3
+semver>=2
 delegator.py
-requests
+requests>=2.32.0
 Flask>=3.0.0
 Pygments>=2.0.0
 litecli>=1.3.0


### PR DESCRIPTION
Note: Touching `httpLib` appears to results in no compilation errors, but breaks all rpc exports - **thus all http server functionality is disabled for now.**
~~Also currently the agent won't compile as frida-screenshot is not yet updated for Frida v17 (https://github.com/nowsecure/frida-screenshot/pull/8).~~ frida-screenshot 6.0.0 has been released!