### PR TITLE
Fixed some issues for compatibility with recent Apktool versions

### DIFF
--- a/objection/utils/patchers/android.py
+++ b/objection/utils/patchers/android.py
@@ -595,32 +595,66 @@ class AndroidPatcher(BasePlatformPatcher):
         # check if the activity path exists. If not, try and see if this may have been
         # a multidex setup
         if not os.path.exists(activity_path):
+            glob_result = self._find_dotnumber_smali(os.path.join(self.apk_temp_directory, 'smali'), target_class)
 
-            click.secho('Smali not found in smali directory. This might be a multidex APK. Searching...', dim=True)
+            if len(glob_result) == 1:
+                activity_path = glob_result[0]
+            else:
+                click.secho('Smali not found in smali directory. This might be a multidex APK. Searching...', dim=True)
 
-            # apk tool will dump the dex classes to a smali directory. in multidex setups
-            # we have folders such as smali_classes2, smali_classes3 etc. we will search
-            # those paths for the launch activity we detected.
-            for x in range(2, 100):
-                smali_path = os.path.join(self.apk_temp_directory, 'smali_classes{0}'.format(x))
+                # apk tool will dump the dex classes to a smali directory. in multidex setups
+                # we have folders such as smali_classes2, smali_classes3 etc. we will search
+                # those paths for the launch activity we detected.
+                for x in range(2, 100):
+                    smali_path = os.path.join(self.apk_temp_directory, 'smali_classes{0}'.format(x))
 
-                # stop if the smali_classes directory does not exist.
-                if not os.path.exists(smali_path):
-                    break
+                    # stop if the smali_classes directory does not exist.
+                    if not os.path.exists(smali_path):
+                        break
 
-                # determine the path to the launchable activity again
-                activity_path = os.path.join(smali_path, target_class) + '.smali'
+                    # determine the path to the launchable activity again
+                    activity_path = os.path.join(smali_path, target_class) + '.smali'
 
-                # if we found the activity, stop the loop
-                if os.path.exists(activity_path):
-                    click.secho('Found smali at: {0}'.format(activity_path), dim=True)
-                    break
+                    # if we found the activity, stop the loop
+                    if os.path.exists(activity_path):
+                        click.secho('Found smali at: {0}'.format(activity_path), dim=True)
+                        break
+
+                    # determine the path to the launchable activity again, this time using glob
+                    glob_result = self._find_dotnumber_smali(smali_path, target_class)
+                    # if we found the activity, stop the loop
+                    if len(glob_result) == 1:
+                        activity_path = os.path.join(smali_path, glob_result[0])
+                        click.secho('Found smali at: {0}'.format(activity_path), dim=True)
+                        break
 
         # one final check to ensure we have the target .smali file
         if not os.path.exists(activity_path):
             raise Exception('Unable to find smali to patch!')
 
         return activity_path
+
+    def _find_dotnumber_smali(self, path: str, target: str) -> list[str]:
+        """
+            Determines whether the target file could be found under a mangled directory under the specified path.
+
+            :param path:
+            :patam target:
+            :return:
+        """
+        parts = target.split('/', 1)
+        if len(parts) == 1:
+            filename = target + ".smali"
+            return [filename] if os.path.exists(os.path.join(path, filename)) else []
+        else:
+            result = []
+            prefix, postfix = parts
+            for entry in os.listdir(path):
+                check = prefix + "."
+                if entry == prefix or (entry.startswith(check) and entry[len(check):].isdigit()):
+                    result.extend((entry + "/" + item for item in
+                                   self._find_dotnumber_smali(os.path.join(path, entry), postfix)))
+            return result
 
     @staticmethod
     def _determine_end_of_smali_method_from_line(smali: list, start: int) -> int:


### PR DESCRIPTION
The command `patchapk` did not work for me using Apktool 2.12.0 – however, I also found some bugs that would have prevented the command to do its job **regardless the Apktool version**.

 - Apktool now tells its version number using the `version` command instead of the `-version` command line argument, resulting in an early crash since version detection fails.
 - Apktool produces weird mangled paths for Smali code, I added code to detect this.
 - Command line arguments for Apktool were passed in a buggy way, I fixed this as well.

**See individual commit messages for more details.**