### PR TITLE
Add support for the latest apktool version in Objection

### DIFF
--- a/objection/commands/mobile_packages.py
+++ b/objection/commands/mobile_packages.py
@@ -223,7 +223,7 @@ def patch_android_apk(source: str, architecture: str, pause: bool, skip_cleanup:
 
         input('Press ENTER to continue...')
 
-    patcher.build_new_apk(use_aapt2=use_aapt2, fix_concurrency_to=fix_concurrency_to)
+    patcher.build_new_apk(fix_concurrency_to=fix_concurrency_to)
     patcher.zipalign_apk()
     if not skip_signing:
         patcher.sign_apk()

--- a/objection/utils/patchers/android.py
+++ b/objection/utils/patchers/android.py
@@ -182,8 +182,8 @@ class AndroidPatcher(BasePlatformPatcher):
     """ Class used to patch Android APK's"""
 
     required_commands = {
-        'aapt': {
-            'installation': 'apt install aapt (Kali Linux)'
+        'aapt2': {
+            'installation': 'Install aapt2 from https://developer.android.com/build/building-cmdline#download_aapt2'
         },
         'adb': {
             'installation': 'apt install adb (Kali Linux); brew install adb (macOS)'
@@ -206,7 +206,7 @@ class AndroidPatcher(BasePlatformPatcher):
         self.apk_temp_directory = tempfile.mkdtemp(suffix='.apktemp')
         self.apk_temp_frida_patched = self.apk_temp_directory + '.objection.apk'
         self.apk_temp_frida_patched_aligned = self.apk_temp_directory + '.aligned.objection.apk'
-        self.aapt = None
+        self.aapt2 = None
         self.skip_cleanup = skip_cleanup
         self.skip_resources = skip_resources
         self.manifest = manifest
@@ -298,26 +298,26 @@ class AndroidPatcher(BasePlatformPatcher):
 
     def _get_appt_output(self):
         """
-            Get the output of `aapt dump badging`.
+            Get the output of `aapt2 dump badging`.
 
             :return:
         """
 
-        if not self.aapt:
+        if not self.aapt2:
             o = delegator.run(self.list2cmdline([
-                self.required_commands['aapt']['location'],
+                self.required_commands['aapt2']['location'],
                 'dump',
                 'badging',
                 self.apk_source
             ]), timeout=self.command_run_timeout)
 
             if len(o.err) > 0:
-                click.secho('An error may have occurred while running aapt.', fg='red')
+                click.secho('An error may have occurred while running aapt2.', fg='red')
                 click.secho(o.err, fg='red')
 
-            self.aapt = o.out
+            self.aapt2 = o.out
 
-        return self.aapt
+        return self.aapt2
 
     def _get_launchable_activity(self) -> str:
         """
@@ -419,7 +419,7 @@ class AndroidPatcher(BasePlatformPatcher):
         if len(o.err) > 0:
             click.secho('An error may have occurred while extracting the APK.', fg='red')
             click.secho(o.err, fg='red')
-            
+
     def inject_internet_permission(self):
         """
             Checks the status of the source APK to see if it

--- a/objection/utils/patchers/android.py
+++ b/objection/utils/patchers/android.py
@@ -227,7 +227,7 @@ class AndroidPatcher(BasePlatformPatcher):
 
         o = delegator.run(self.list2cmdline([
             self.required_commands['apktool']['location'],
-            '-version',
+            'v',
         ]), timeout=self.command_run_timeout).out.strip()
 
         # On windows we get this 'Press any key to continue' thing,

--- a/objection/utils/patchers/android.py
+++ b/objection/utils/patchers/android.py
@@ -400,16 +400,21 @@ class AndroidPatcher(BasePlatformPatcher):
 
         click.secho('Unpacking {0}'.format(self.apk_source), dim=True)
 
-        o = delegator.run(self.list2cmdline([
-            self.required_commands['apktool']['location'],
-            'decode',
-            '-f',
-            '-r' if self.skip_resources else '',
-            '--only-main-classes' if self.only_main_classes else '',
-            '-o',
-            self.apk_temp_directory,
-            self.apk_source
-        ] + ([] if fix_concurrency_to is None else ['-j', fix_concurrency_to])), timeout=self.command_run_timeout)
+        o = delegator.run(
+            self.list2cmdline(filter(None, [
+                self.required_commands['apktool']['location'],
+                'decode',
+                '-f',
+                '-r' if self.skip_resources else None,
+                '--only-main-classes' if self.only_main_classes else None,
+                '-o',
+                self.apk_temp_directory,
+                self.apk_source,
+                '-j' if fix_concurrency_to else None,
+                fix_concurrency_to
+            ])),
+            timeout=self.command_run_timeout
+        )
 
         if len(o.err) > 0:
             click.secho('An error may have occurred while extracting the APK.', fg='red')

--- a/objection/utils/patchers/android.py
+++ b/objection/utils/patchers/android.py
@@ -883,7 +883,7 @@ class AndroidPatcher(BasePlatformPatcher):
             click.secho('Adding a gadget configuration file...', fg='green')
             shutil.copyfile(gadget_config, os.path.join(libs_path, 'libfrida-gadget.config.so'))
 
-    def build_new_apk(self, use_aapt2: bool = False, fix_concurrency_to = None):
+    def build_new_apk(self, fix_concurrency_to = None):
         """
             Build a new .apk with the frida-gadget patched in.
 
@@ -892,15 +892,17 @@ class AndroidPatcher(BasePlatformPatcher):
 
         click.secho('Rebuilding the APK with the frida-gadget loaded...', fg='green', dim=True)
         o = delegator.run(
-            self.list2cmdline([self.required_commands['apktool']['location'],
-                            'build',
-                            self.apk_temp_directory,
-                            ] + (['--use-aapt2'] if use_aapt2 else []) + [
-                                '-o',
-                                self.apk_temp_frida_patched
-                            ]+ ([] if fix_concurrency_to is None else ['-j', fix_concurrency_to]))
-                            , timeout=self.command_run_timeout)
-        
+            self.list2cmdline(filter(None, [
+                self.required_commands['apktool']['location'],
+                'b',
+                self.apk_temp_directory,
+                '-o',
+                self.apk_temp_frida_patched,
+                '-j' if fix_concurrency_to else None,
+                fix_concurrency_to
+            ])),
+            timeout=self.command_run_timeout
+        )
 
         if len(o.err) > 0:
             click.secho(('Rebuilding the APK may have failed. Read the following '


### PR DESCRIPTION
## Description

This PR updates Objection to fully support the latest apktool version by:

- Switching from `aapt` to `aapt2`, which is now the default in apktool.
- Removing the deprecated `--use-aapt2` flag.
- Fixing command construction to avoid passing empty string arguments to apktool.
- Updating the version check command to use `v` instead of the old `-version` flag.

These updates ensure Objection remains compatible and stable with the newest apktool releases.

Here is the log:

```
❯ objection patchapk -s fluttersamples.apk -a arm64
Using latest Github gadget version: 17.3.0
Patcher will be using Gadget version: 17.3.0
Detected apktool version as: 2.12.0
Running apktool empty-framework-dir...
I: Removing framework file: 1.apk
Unpacking fluttersamples.apk
App already has android.permission.INTERNET
Target class not specified, searching for launchable activity instead...
Reading smali from: /var/folders/_8/v5b47jgd4p529gtngdp1778c0000gn/T/tmpi05vnu2h.apktemp/smali/cm/aptoide/pt/view/MainActivity.smali
Injecting loadLibrary call at line: 86
Attempting to fix the constructors .locals count
Current locals value is 0, updating to 1:
Writing patched smali back to: /var/folders/_8/v5b47jgd4p529gtngdp1778c0000gn/T/tmpi05vnu2h.apktemp/smali/cm/aptoide/pt/view/MainActivity.smali
Creating library path: /var/folders/_8/v5b47jgd4p529gtngdp1778c0000gn/T/tmpi05vnu2h.apktemp/lib/arm64
Copying Frida gadget to libs path...
Rebuilding the APK with the frida-gadget loaded...
Built new APK with injected loadLibrary and frida-gadget
Performing zipalign
Zipalign completed
Signing new APK.
Signing the new APK may have failed.

WARNING: A restricted method in java.lang.System has been called
WARNING: java.lang.System::loadLibrary has been called by org.conscrypt.NativeLibraryUtil in an unnamed module (file:/Users/Library/Android/sdk/build-tools/36.0.0/lib/apksigner.jar)
WARNING: Use --enable-native-access=ALL-UNNAMED to avoid a warning for callers in this module
WARNING: Restricted methods will be blocked in a future release unless native access is enabled

Unexpected parameter(s) after input APK (--enable-native-access=ALL-UNNAMED)

Signed the new APK
Copying final apk from /var/folders/_8/v5b47jgd4p529gtngdp1778c0000gn/T/tmpi05vnu2h.apktemp.aligned.objection.apk to fluttersamples.objection.apk in current directory...
Cleaning up temp files...

❯ ls | grep flutter
fluttersamples.apk
fluttersamples.objection.apk
```