### PR TITLE
Add ios nsuserdefaults set command

### DIFF
--- a/agent/src/ios/nsuserdefaults.ts
+++ b/agent/src/ios/nsuserdefaults.ts
@@ -8,11 +8,38 @@ import {
 export const get = (): NSUserDefaults | any => {
   // -- Sample Objective-C
   //
-  // NSUserDefaults *d = [[NSUserDefaults alloc] init];
+  // NSUserDefaults *d = [NSUserDefaults standardUserDefaults];
   // NSLog(@"%@", [d dictionaryRepresentation]);
 
-  const defaults: NSUserDefaults = ObjC.classes.NSUserDefaults;
-  const data: NSDictionary = defaults.alloc().init().dictionaryRepresentation();
+  const defaults: NSUserDefaults = ObjC.classes.NSUserDefaults.standardUserDefaults();
+  const data: NSDictionary = defaults.dictionaryRepresentation();
 
   return data.toString();
+};
+
+export const set = (key: string, value: any, valueType?: string): boolean => {
+  // -- Sample Objective-C
+  //
+  // NSUserDefaults *d = [NSUserDefaults standardUserDefaults];
+  // [d setObject:value forKey:key];
+  // [d synchronize];
+
+  const defaults: NSUserDefaults = ObjC.classes.NSUserDefaults.standardUserDefaults();
+
+  // Determine type and set accordingly
+  if (valueType === "bool") {
+    defaults.setBool_forKey_(value, key);
+  } else if (valueType === "int") {
+    defaults.setInteger_forKey_(value, key);
+  } else if (valueType === "float") {
+    defaults.setDouble_forKey_(value, key);
+  } else {
+    // Default to string/object
+    defaults.setObject_forKey_(value, key);
+  }
+
+  // Persist to disk
+  defaults.synchronize();
+
+  return true;
 };

--- a/agent/src/rpc/ios.ts
+++ b/agent/src/rpc/ios.ts
@@ -105,4 +105,5 @@ export const ios = {
 
   // ios nsuserdefaults
   iosNsuserDefaultsGet: (): NSUserDefaults | any => nsuserdefaults.get(),
+  iosNsuserDefaultsSet: (key: string, value: any, valueType?: string): boolean => nsuserdefaults.set(key, value, valueType),
 };

--- a/objection/commands/ios/nsuserdefaults.py
+++ b/objection/commands/ios/nsuserdefaults.py
@@ -3,6 +3,18 @@ import click
 from objection.state.connection import state_connection
 
 
+def _get_flag_value(args: list, flag: str) -> str:
+    """
+        Returns the value for a flag.
+
+        :param args:
+        :param flag:
+        :return:
+    """
+
+    return args[args.index(flag) + 1] if flag in args else None
+
+
 def get(args: list = None) -> None:
     """
         Gets all of the values stored in NSUserDefaults and prints
@@ -16,3 +28,78 @@ def get(args: list = None) -> None:
     defaults = api.ios_nsuser_defaults_get()
 
     click.secho(defaults, bold=True)
+
+
+def set(args: list = None) -> None:
+    """
+        Sets a value in NSUserDefaults.
+
+        :param args:
+        :return:
+    """
+
+    if not args or len(args) < 2:
+        click.secho('Usage: ios nsuserdefaults set <key> <value> [--type string|int|float|bool]', fg='red')
+        return
+
+    # Get explicit type if provided
+    value_type = _get_flag_value(args, '--type')
+
+    # Remove --type and its value from args if present
+    if '--type' in args:
+        type_index = args.index('--type')
+        args = args[:type_index] + args[type_index + 2:]
+
+    if len(args) < 2:
+        click.secho('Usage: ios nsuserdefaults set <key> <value> [--type string|int|float|bool]', fg='red')
+        return
+
+    key = args[0]
+    value_str = args[1]
+
+    # Parse value based on type
+    if value_type == 'bool':
+        value = value_str.lower() in ['true', '1', 'yes']
+    elif value_type == 'int':
+        try:
+            value = int(value_str)
+        except ValueError:
+            click.secho(f'Invalid integer value: {value_str}', fg='red')
+            return
+    elif value_type == 'float':
+        try:
+            value = float(value_str)
+        except ValueError:
+            click.secho(f'Invalid float value: {value_str}', fg='red')
+            return
+    else:
+        # Default to string, but try to auto-detect type
+        if not value_type:
+            if value_str.lower() in ['true', 'false']:
+                value_type = 'bool'
+                value = value_str.lower() == 'true'
+            elif value_str.isdigit() or (value_str.startswith('-') and value_str[1:].isdigit()):
+                value_type = 'int'
+                value = int(value_str)
+            elif '.' in value_str:
+                try:
+                    value = float(value_str)
+                    value_type = 'float'
+                except ValueError:
+                    value = value_str
+                    value_type = 'string'
+            else:
+                value = value_str
+                value_type = 'string'
+        else:
+            value = value_str
+
+    click.secho(f'Setting NSUserDefaults key: {key} = {value} (type: {value_type})', dim=True)
+
+    api = state_connection.get_api()
+    result = api.ios_nsuser_defaults_set(key, value, value_type)
+
+    if result:
+        click.secho(f'Successfully set {key}', fg='green')
+    else:
+        click.secho(f'Failed to set {key}', fg='red')

--- a/objection/console/commands.py
+++ b/objection/console/commands.py
@@ -588,6 +588,10 @@ COMMANDS = {
                     'get': {
                         'meta': 'Get all of the entries',
                         'exec': nsuserdefaults.get
+                    },
+                    'set': {
+                        'meta': 'Set a value for a key',
+                        'exec': nsuserdefaults.set
                     }
                 }
             },

--- a/objection/console/helpfiles/ios.nsuserdefaults.set.txt
+++ b/objection/console/helpfiles/ios.nsuserdefaults.set.txt
@@ -1,0 +1,25 @@
+Command: ios nsuserdefaults set
+
+Usage: ios nsuserdefaults set <key> <value> [--type string|int|float|bool]
+
+Sets a value in the application's NSUserDefaults for the specified key.
+The command will attempt to auto-detect the value type based on the input,
+but you can explicitly specify the type using the --type flag.
+
+Type Detection:
+  - "true" or "false" -> boolean
+  - Numbers without decimal -> integer
+  - Numbers with decimal -> float
+  - Everything else -> string
+
+Arguments:
+  <key>        The NSUserDefaults key to set
+  <value>      The value to store
+  --type       Optional: Explicitly specify the value type (string|int|float|bool)
+
+Examples:
+   ios nsuserdefaults set username "john.doe"
+   ios nsuserdefaults set isFirstLaunch false
+   ios nsuserdefaults set loginAttempts 3
+   ios nsuserdefaults set apiVersion 2.5
+   ios nsuserdefaults set debugMode true --type bool

--- a/tests/commands/ios/test_nsuserdefaults.py
+++ b/tests/commands/ios/test_nsuserdefaults.py
@@ -1,7 +1,7 @@
 import unittest
 from unittest import mock
 
-from objection.commands.ios.nsuserdefaults import get
+from objection.commands.ios.nsuserdefaults import get, set
 from ...helpers import capture
 
 
@@ -14,3 +14,57 @@ class TestNsuserdefaults(unittest.TestCase):
             output = o
 
         self.assertEqual(output, 'foo\n')
+
+    @mock.patch('objection.state.connection.state_connection.get_api')
+    def test_set_string(self, mock_api):
+        mock_api.return_value.ios_nsuser_defaults_set.return_value = True
+
+        with capture(set, ['testKey', 'testValue']) as o:
+            output = o
+
+        self.assertIn('Successfully set testKey', output)
+        mock_api.return_value.ios_nsuser_defaults_set.assert_called_once_with('testKey', 'testValue', 'string')
+
+    @mock.patch('objection.state.connection.state_connection.get_api')
+    def test_set_bool(self, mock_api):
+        mock_api.return_value.ios_nsuser_defaults_set.return_value = True
+
+        with capture(set, ['isEnabled', 'true']) as o:
+            output = o
+
+        self.assertIn('Successfully set isEnabled', output)
+        mock_api.return_value.ios_nsuser_defaults_set.assert_called_once_with('isEnabled', True, 'bool')
+
+    @mock.patch('objection.state.connection.state_connection.get_api')
+    def test_set_int(self, mock_api):
+        mock_api.return_value.ios_nsuser_defaults_set.return_value = True
+
+        with capture(set, ['count', '42']) as o:
+            output = o
+
+        self.assertIn('Successfully set count', output)
+        mock_api.return_value.ios_nsuser_defaults_set.assert_called_once_with('count', 42, 'int')
+
+    @mock.patch('objection.state.connection.state_connection.get_api')
+    def test_set_with_explicit_type(self, mock_api):
+        mock_api.return_value.ios_nsuser_defaults_set.return_value = True
+
+        with capture(set, ['version', '2.5', '--type', 'float']) as o:
+            output = o
+
+        self.assertIn('Successfully set version', output)
+        mock_api.return_value.ios_nsuser_defaults_set.assert_called_once_with('version', 2.5, 'float')
+
+    @mock.patch('objection.state.connection.state_connection.get_api')
+    def test_set_missing_arguments(self, mock_api):
+        with capture(set, ['onlyKey']) as o:
+            output = o
+
+        self.assertIn('Usage:', output)
+
+    @mock.patch('objection.state.connection.state_connection.get_api')
+    def test_set_no_arguments(self, mock_api):
+        with capture(set, []) as o:
+            output = o
+
+        self.assertIn('Usage:', output)


### PR DESCRIPTION
This PR adds a new command to set values in iOS NSUserDefaults, complementing the existing get command.

## Features

- Set string, integer, float, and boolean values in NSUserDefaults
- Automatic type detection based on input
- Optional `--type` flag for explicit type specification
- Changes persist across app restarts via `synchronize()`

## Usage
```bash
ios nsuserdefaults set <key> <value> [--type string|int|float|bool]```

## Examples

```bash
ios nsuserdefaults set username "john.doe"
ios nsuserdefaults set isEnabled true
ios nsuserdefaults set maxRetries 5
ios nsuserdefaults set apiVersion 2.5 --type float
```

## Changes

- **TypeScript Agent**: Implemented `set()` function with type-specific setters (`setBool_forKey_`, `setInteger_forKey_`, `setDouble_forKey_`, `setObject_forKey_`)
- **TypeScript Agent**: Fixed `get()` to use `standardUserDefaults()` for consistency with `set()`
- **RPC Layer**: Added `iosNsuserDefaultsSet` export
- **Python Command**: Added `set()` command with argument parsing and intelligent type detection
- **Tests**: Added 6 new test cases covering all value types and error scenarios
- **Documentation**: Added help file with usage examples

## Testing

All tests pass:

```bash
python -m unittest tests.commands.ios.test_nsuserdefaults -v
```
