### PR TITLE
fix: correct ObjC reference in Frida 17.x compatibility layer

### DIFF
--- a/agent/src/ios/lib/libobjc.ts
+++ b/agent/src/ios/lib/libobjc.ts
@@ -2,8 +2,8 @@ import ObjC_bridge from "frida-objc-bridge";
 
 let ObjC: typeof ObjC_bridge;
 // Compatibility with frida < 17
-if (globalThis.ObjC) { 
-  ObjC = globalThis.Java
+if (globalThis.ObjC) {
+  ObjC = globalThis.ObjC
 } else {
   ObjC = ObjC_bridge
 }


### PR DESCRIPTION
Fixes a typo in the Frida version compatibility check where globalThis.Java was incorrectly assigned instead of globalThis.ObjC.

This typo caused a ReferenceError when the agent attempted to use ObjC methods on iOS devices running Frida 17.x, specifically when calling env_runtime() and other iOS-specific functions.

The fix ensures that when globalThis.ObjC exists (Frida < 17), it is correctly assigned to the ObjC variable instead of Java.

Fixes #740

Tested-on:
- Frida 17.0.7
- iOS 16.7.10 (jailbroken device)
- DVIA-v2 test application