### PR TITLE
fix: support bundle identifier when attaching to iOS processes

### DIFF
--- a/objection/utils/agent.py
+++ b/objection/utils/agent.py
@@ -231,8 +231,34 @@ class Agent(object):
                 pass
 
             if self.pid is None:
-                # last resort, maybe we have a process name
-                self.pid = self.device.get_process(self.config.name).pid
+                try:
+                    self.pid = self.device.get_process(self.config.name).pid
+                except:
+                    processes = self.device.enumerate_processes()
+                    for process in processes:
+                        try:
+                            app = self.device.get_frontmost_application()
+                            if app and app.identifier == self.config.name:
+                                self.pid = app.pid
+                                break
+                        except:
+                            pass
+
+                    if self.pid is None:
+                        try:
+                            applications = self.device.enumerate_applications()
+                            for app in applications:
+                                if app.identifier == self.config.name:
+                                    for process in processes:
+                                        if process.name == app.name:
+                                            self.pid = process.pid
+                                            break
+                                    break
+                        except:
+                            pass
+
+                    if self.pid is None:
+                        raise Exception(f'Unable to find process with name or identifier: {self.config.name}')
 
         debug_print(f'process PID determined as {self.pid}')
 


### PR DESCRIPTION
Adds support for using bundle identifiers (e.g., com.apple.Preferences) in addition to process names when attaching to running processes.

Previously, objection only supported process names or PIDs when attaching. Using a bundle identifier would result in a ProcessNotFoundError because get_process() only matches against process names.

This change implements a fallback mechanism that:
1. First tries the existing get_process() with the provided name
2. If that fails, enumerates all running applications
3. Matches the bundle identifier to find the correct application
4. Maps the application name to its running process
5. Returns the PID for attachment

This makes the attach workflow more user-friendly by accepting the same bundle identifier format used by frida-ps and other tools, eliminating the need to manually look up process names.

Fixes #401
Fixes #445

Tested-on:
- Frida 17.0.7
- iOS 16.7.10 (jailbroken device)
- Multiple iOS applications with bundle identifiers