### PR TITLE
Add /var/jb to jailbreak detection paths

### DIFF
--- a/agent/src/ios/jailbreak.ts
+++ b/agent/src/ios/jailbreak.ts
@@ -45,6 +45,7 @@ const jailbreakPaths = [
   "/var/lib/cydia",
   "/var/log/syslog",
   "/var/tmp/cydia.log",
+  "/var/jb"
 ];
 
 


### PR DESCRIPTION
Added /var/jb path which is used by modern jailbreaks like Dopamine and Palera1n on iOS 15+.