### PR TITLE
Fix Python 3.10 compatibility by falling back to tomli

### DIFF
--- a/objection/__init__.py
+++ b/objection/__init__.py
@@ -2,7 +2,10 @@ import sys
 from importlib import metadata
 from pathlib import Path
 
-import tomllib
+try:
+    import tomllib
+except ModuleNotFoundError:
+    import tomli as tomllib
 
 
 def _load_version() -> str:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ dependencies = [
     "semver>=2",
     "setuptools>=70.0.0",
     "tabulate>=0.9.0",
+    "tomli>=2.0.0; python_version < '3.11'",
 ]
 
 [project.urls]


### PR DESCRIPTION
## Summary

This PR restores Python 3.10 compatibility by falling back to `tomli` when `tomllib` is unavailable.

## Problem

`tomllib` is only part of the Python standard library starting from Python 3.11.

The current code imports `tomllib` directly, which causes Objection to fail at startup on Python 3.10 with:

```python
ModuleNotFoundError: No module named 'tomllib'
```

This is especially confusing because the package can still be installed successfully on Python 3.10, but then crashes immediately when executed.

## Fix

Use a compatibility import:

```python
try:
    import tomllib
except ModuleNotFoundError:
    import tomli as tomllib
```

Also declare `tomli` as a dependency for Python versions below 3.11.

## Why this approach

- Keeps Python 3.11+ using the standard library implementation
- Restores support for Python 3.10 with minimal change
- Avoids forcing users to discover the issue only at runtime
