### PR TITLE
fix(android) : handle non-standard version strings from custom ROMs

### DIFF
--- a/objection/utils/helpers.py
+++ b/objection/utils/helpers.py
@@ -124,6 +124,10 @@ def print_frida_connection_help() -> None:
     click.secho('')
     click.secho('For more information, please refer to the objection wiki at: '
                 'https://github.com/sensepost/objection/wiki', fg='green')
+    
+def sanitize_version(version_str: str) -> str:
+    match = re.search(r"\d+(\.\d+)?", version_str or "")
+    return match.group(0) if match else "0"
 
 
 def warn_about_older_operating_systems() -> None:
@@ -143,12 +147,16 @@ def warn_about_older_operating_systems() -> None:
     ios_supported = '9'
 
     # android & ios version warnings
-    if platform == Android and (
-            Version(version) < Version(android_supported)):
-        click.secho('Warning: You appear to be running Android {0} which may result in '
+    if platform == Android:
+        clean_version = sanitize_version(version)
+        try:
+            if Version(clean_version) < Version(android_supported):
+                click.secho('Warning: You appear to be running Android {0} which may result in '
                     'some hooks failing.\nIt is recommended to use at least an Android '
                     'version {1} device with objection.'.format(version, android_supported),
                     fg='yellow')
+        except Exception:
+            pass
 
     # android & ios version warnings
     if platform == Ios and (


### PR DESCRIPTION
Some Android distributions (e.g. crDroid, Evolution X) append additional identifiers to ro.build.version.release, causing packaging.version.Version to raise InvalidVersion.

This patch sanitizes the version string before parsing to ensure compatibility and prevent crashes.