### PR TITLE
fix: require Python >=3.11 to match stdlib tomllib import

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "objection"
 version = "1.12.5"
 description = "Instrumented Mobile Pentest Framework"
 readme = "README.md"
-requires-python = ">=3.10"
+requires-python = ">=3.11"
 license = "GPL-3.0-or-later"
 authors = [{name = "Leon Jacobs", email = "leon@sensepost.com"}]
 keywords = ["mobile", "instrumentation", "pentest", "frida", "hook"]


### PR DESCRIPTION
## Summary

`objection/__init__.py` imports `tomllib` at module level, but `tomllib` only exists in the standard library from Python 3.11. Since `pyproject.toml` declared `requires-python = ">=3.10"`, installation succeeded on Python 3.10 but `import objection` immediately crashed with `ModuleNotFoundError: No module named 'tomllib'`.

As suggested by @IPMegladon in the issue thread, this bumps the version requirement rather than adding a `tomli` fallback dependency.

Fixes #799

## Changes

- `pyproject.toml`: `requires-python` bumped from `>=3.10` to `>=3.11` so pip refuses installation on Python versions where `tomllib` is unavailable